### PR TITLE
Add Petersburg Block to aleut genesis.json

### DIFF
--- a/network-upgrades/client-integration-testnets/aleut.md
+++ b/network-upgrades/client-integration-testnets/aleut.md
@@ -29,6 +29,7 @@ The specification for the Aleut Client Integration Tesnet. Clients who wish to s
       "byzantiumBlock":0,
       "constantinopleBlock":0,
       "constantinopleFixBlock":0,
+      "petersburgBlock":0,
       "istanbulBlock":0,
       "muirGlacierBlock":0,
       "berlinBlock":0,


### PR DESCRIPTION
Without this change Geth gives the error `Fatal: Failed to write genesis block: unsupported fork ordering: petersburgBlock not enabled, but istanbulBlock enabled at 0`