### PR TITLE
Add eth_maxPriorityFeePerGas

### DIFF
--- a/json-rpc/spec.json
+++ b/json-rpc/spec.json
@@ -197,6 +197,22 @@
 			}
 		},
 		{
+			"name": "eth_maxFeePerGas",
+			"summary": "Returns a maxFeePerGas value suitable for quick transaction inclusion",
+			"params": [],
+			"result": {
+				"$ref": "#/components/contentDescriptors/MaxFeePerGas"
+			}
+		},
+		{
+			"name": "eth_maxPriorityFeePerGas",
+			"summary": "Returns a maxPriorityFeePerGas value suitable for quick transaction inclusion",
+			"params": [],
+			"result": {
+				"$ref": "#/components/contentDescriptors/MaxPriorityFeePerGas"
+			}
+		},
+		{
 			"name": "eth_getBalance",
 			"summary": "Returns Ether balance of a given or account or contract",
 			"params": [
@@ -1758,6 +1774,24 @@
 					"title": "gasPriceResult",
 					"description": "Integer of the current gas price",
 					"$ref": "#/components/schemas/Integer"
+				}
+			},
+			"MaxFeePerGas": {
+				"name": "maxFeePerGas",
+				"required": true,
+				"schema": {
+					"title": "maxFeeCapPerGas",
+					"description": "Integer of the max fee per gas",
+					"$ref": "#/components/schemas/Integer256"
+				}
+			},
+			"MaxPriorityFeePerGas": {
+				"name": "maxPriorityFeePerGas",
+				"required": true,
+				"schema": {
+					"title": "maxPriorityFeePerGas",
+					"description": "Integer of the max priority fee per gas",
+					"$ref": "#/components/schemas/Integer256"
 				}
 			},
 			"Transaction": {

--- a/json-rpc/spec.json
+++ b/json-rpc/spec.json
@@ -197,14 +197,6 @@
 			}
 		},
 		{
-			"name": "eth_maxFeePerGas",
-			"summary": "Returns a maxFeePerGas value suitable for quick transaction inclusion",
-			"params": [],
-			"result": {
-				"$ref": "#/components/contentDescriptors/MaxFeePerGas"
-			}
-		},
-		{
 			"name": "eth_maxPriorityFeePerGas",
 			"summary": "Returns a maxPriorityFeePerGas value suitable for quick transaction inclusion",
 			"params": [],
@@ -1774,15 +1766,6 @@
 					"title": "gasPriceResult",
 					"description": "Integer of the current gas price",
 					"$ref": "#/components/schemas/Integer"
-				}
-			},
-			"MaxFeePerGas": {
-				"name": "maxFeePerGas",
-				"required": true,
-				"schema": {
-					"title": "maxFeeCapPerGas",
-					"description": "Integer of the max fee per gas",
-					"$ref": "#/components/schemas/Integer256"
 				}
 			},
 			"MaxPriorityFeePerGas": {


### PR DESCRIPTION
This PR adds two new RPC methods:
* ~~`eth_maxFeePerGas` -- returns a `maxFeePerGas` estimate for quick inclusion~~
* `eth_maxPriorityFeePerGas` -- returns a `maxPriorityPerGas` estimate for quick inclusion

An alternative to introducing two new methods is to add an optional flag to `eth_gasPrice` that denotes whether the caller is interested in a `gasPrice` estimate or a EIP-1559 fee estimate. I have a weak preference for the two methods.

I'll keep this as a draft until we feel there is good consensus on this issue.

cc: @tkstanczak, @ryanschneider, @MicahZoltu