### PR TITLE
Open spec in openrpc viewer

### DIFF
--- a/json-rpc/README.md
+++ b/json-rpc/README.md
@@ -1,6 +1,6 @@
 # Ethereum JSON-RPC Specification
 
-[View the spec](https://raw.githubusercontent.com/ethereum/eth1.0-specs/master/json-rpc/spec.json)
+[View the spec](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/ethereum/eth1.0-specs/master/json-rpc/spec.json&uiSchema%5BappBar%5D%5Bui:input%5D=false)
 
 The Ethereum JSON-RPC is a collection of methods that all clients implement.
 This interface allows downstream tooling and infrastructure to treat different


### PR DESCRIPTION
This will allow people to open the RPC spec in the nice OpenRPC viewer. Eventually we'll want to get the hosted on an `ethereum.org` subdomain, but this should do for now. :)