### PR TITLE
add feeHistory spec

### DIFF
--- a/json-rpc/spec.json
+++ b/json-rpc/spec.json
@@ -197,6 +197,96 @@
 			}
 		},
 		{
+			"name": "eth_feeHistory",
+			"summary": "Transaction fee history",
+			"description": "Returns base fee per gas and transaction effective priority fee per gas history for the requested block range if available. The range between headBlock-4 and headBlock is guaranteed to be available while retrieving data from the pending block and older history are optional to support. For pre-EIP-1559 blocks the gas prices are returned as rewards and zeroes are returned for the base fee per gas.",
+			"params": [
+				{
+					"name": "blockCount",
+					"description": "Number of blocks in the requested range. Between 1 and 1024 blocks can be requested in a single query. Less than requested may be returned if not all blocks are available.",
+					"required": true,
+					"schema": {
+						"$ref": "#/components/schemas/Integer"
+					}
+				},
+				{
+					"name": "newestBlock",
+					"description": "Highest number block of the requested range.",
+					"required": true,
+					"schema": {
+						"$ref": "#/components/schemas/BlockNumberOrTag"
+					}
+				},
+				{
+					"name": "rewardPercentiles",
+					"description": "A monotonically increasing list of percentile values to sample from each block's effective priority fees per gas in ascending order, weighted by gas used.",
+					"schema": {
+						"title": "rewardPercentiles",
+						"type": "array",
+						"items": {
+							"title": "rewardPercentile",
+							"description": "Floating point value between 0 and 100.",
+							"type": "number"
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "feeHistoryResult",
+				"description": "Fee history for the returned block range. This can be a subsection of the requested range if not all blocks are available.",
+				"schema": {
+					"title": "feeHistoryResults",
+					"description": "Fee history results",
+					"type": "object",
+					"required": [
+						"firstBlock",
+						"baseFeePerGas",
+						"gasUsedRatio"
+					],
+					"properties": {
+						"oldestBlock": {
+							"title": "oldestBlock",
+							"description": "Lowest number block of the returned range.",
+							"$ref": "#/components/schemas/BlockNumber"
+						},
+						"baseFeePerGas": {
+							"title": "baseFeePerGasArray",
+							"description": "An array of block base fees per gas. This includes the next block after the newest of the returned range, because this value can be derived from the newest block. Zeroes are returned for pre-EIP-1559 blocks.",
+							"type": "array",
+							"items": {
+								"$ref": "#/components/schemas/Integer"
+							}
+						},
+						"gasUsedRatio": {
+							"title": "gasUsedArray",
+							"description": "An array of block gas used ratios. These are calculated as the ratio of gasUsed and gasLimit.",
+							"type": "array",
+							"items": {
+								"title": "gasUsedRatio",
+								"description": "Floating point value between 0 and 1.",
+								"type": "number"
+							}
+						},
+						"reward": {
+							"title": "rewardArray",
+							"description": "A two-dimensional array of effective priority fees per gas at the requested block percentiles.",
+							"type": "array",
+							"items": {
+								"title": "rewardPercentileArray",
+								"description": "An array of effective priority fee per gas data points from a single block. All zeroes are returned if the block is empty.",
+								"type": "array",
+								"items": {
+									"title": "rewardPercentile",
+									"description": "A given percentile sample of effective priority fees per gas from a single block in ascending order, weighted by gas used. Zeroes are returned if the block is empty.",
+									"$ref": "#/components/schemas/Integer"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		{
 			"name": "eth_getBalance",
 			"summary": "Returns Ether balance of a given or account or contract",
 			"params": [
@@ -1135,6 +1225,17 @@
 					"pending"
 				]
 			},
+			"BlockNumberOrTag": {
+				"title": "blockNumberOrTag",
+				"oneOf": [
+					{
+						"$ref": "#/components/schemas/BlockNumber"
+					},
+					{
+						"$ref": "#/components/schemas/BlockNumberTag"
+					}
+				]
+			},
 			"BlockOrNull": {
 				"title": "blockOrNull",
 				"oneOf": [
@@ -1881,15 +1982,7 @@
 				"name": "blockNumber",
 				"required": true,
 				"schema": {
-					"title": "blockNumberOrTag",
-					"oneOf": [
-						{
-							"$ref": "#/components/schemas/BlockNumber"
-						},
-						{
-							"$ref": "#/components/schemas/BlockNumberTag"
-						}
-					]
+					"$ref": "#/components/schemas/BlockNumberOrTag"
 				}
 			},
 			"TransactionHash": {


### PR DESCRIPTION
This PR adds the feeHistory API function spec.
See also:
- original proposal: https://gist.github.com/zsfelfoldi/9607ad248707a925b701f49787904fd6
- implementation in Geth: https://github.com/ethereum/go-ethereum/pull/23033