### PR TITLE
Explicitly state value of base fee pre and post EIP-1559

### DIFF
--- a/json-rpc/spec.json
+++ b/json-rpc/spec.json
@@ -1594,7 +1594,7 @@
 					},
 					"baseFeePerGas": {
 						"title": "baseFeePerGas",
-						"description": "The block's baseline network fee per gas; the baseFee is burned",
+						"description": "The block's baseline network fee per gas; the baseFee is burned. Before London, this field must empty. After London, this field must be set to the block's base fee per gas value.",
 						"$ref": "#/components/schemas/Integer"
 					}
 				}


### PR DESCRIPTION
closes #210

Eventually, may be better to explicitly type the blocks pre and post EIP-1559. But I'd need to figure out if OpenRPC supports semantic validation.