### PR TITLE
Omit `effectiveGasPrice` before EIP-1559

### DIFF
--- a/json-rpc/spec.json
+++ b/json-rpc/spec.json
@@ -1318,7 +1318,7 @@
 					},
 					"effectiveGasPrice": {
 						"title": "ReceiptEffectiveGasPrice",
-						"description": "The actual value per gas deducted from the senders account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas). Legacy transactions and EIP-2930 transactions are coerced into the EIP-1559 format by setting both maxFeePerGas and maxPriorityFeePerGas as the transaction's gas price.",
+						"description": "The actual value per gas deducted from the senders account. Before EIP-1559, this value is omitted. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas). Legacy transactions and EIP-2930 transactions are coerced into the EIP-1559 format by setting both maxFeePerGas and maxPriorityFeePerGas as the transaction's gas price.",
 						"$ref": "#components/schemas/Integer"
 					},
 					"logs": {


### PR DESCRIPTION
~~It [appears](https://github.com/ethereum/go-ethereum/blob/4fcc93d9229e99b14d3d1500f05ada6ba1f789bb/internal/ethapi/api.go#L1599-L1600) geth is currently omitting `effectiveGasPrice` from the RPC for pre-London blocks.~~ Sorry for the mistake! OE [prefers](https://github.com/openethereum/openethereum/pull/450) to do the same.

I weakly prefer keeping as-is so tooling doesn't have to potentially look in two places to see the `effectiveGasPrice`. This PR is to discuss the merits of that.