### PR TITLE
Propose Block for London Mainnet Activation

### DIFF
--- a/network-upgrades/mainnet-upgrades/london.md
+++ b/network-upgrades/mainnet-upgrades/london.md
@@ -17,7 +17,7 @@ Specifies changes included in the Network Upgrade.
 | Goerli  | `5062605`  | June 30, 2021 | `0xB8C6299D` | 
 | Rinkeby | `8897988`  | July 7, 2021  | `0x8E29F2F3` | 
 | Kovan   | TBA        | TBA           | TBA          | 
-| Mainnet | TBA        | TBA           | TBA          | 
+| Mainnet | `12965000` | August 4, 2021 | TBA          | 
 
 ### Client Readiness Checklist
 Code merged into Participating Clients

--- a/network-upgrades/mainnet-upgrades/london.md
+++ b/network-upgrades/mainnet-upgrades/london.md
@@ -11,12 +11,12 @@ Specifies changes included in the Network Upgrade.
 
 ### Upgrade Schedule
 
-| Network | Block      | Expected Date | Fork ID      | 
+| Network | Block      | Expected Date | Fork Hash    |
 |---------|------------|---------------|--------------|
-| Ropsten | `10499401` | June 24, 2021 | `0x7119B6B3` | 
-| Goerli  | `5062605`  | June 30, 2021 | `0xB8C6299D` | 
-| Rinkeby | `8897988`  | July 7, 2021  | `0x8E29F2F3` | 
-| Kovan   | TBA        | TBA           | TBA          | 
+| Ropsten | `10499401` | June 24, 2021 | `0x7119B6B3` |
+| Goerli  | `5062605`  | June 30, 2021 | `0xB8C6299D` |
+| Rinkeby | `8897988`  | July 7, 2021  | `0x8E29F2F3` |
+| Kovan   | TBA        | TBA           | TBA          |
 | Mainnet | `12965000` | August 4, 2021 | `0xB715077D` | 
 
 ### Client Readiness Checklist

--- a/network-upgrades/mainnet-upgrades/london.md
+++ b/network-upgrades/mainnet-upgrades/london.md
@@ -17,7 +17,7 @@ Specifies changes included in the Network Upgrade.
 | Goerli  | `5062605`  | June 30, 2021 | `0xB8C6299D` | 
 | Rinkeby | `8897988`  | July 7, 2021  | `0x8E29F2F3` | 
 | Kovan   | TBA        | TBA           | TBA          | 
-| Mainnet | `12965000` | August 4, 2021 | TBA          | 
+| Mainnet | `12965000` | August 4, 2021 | `0xB715077D` | 
 
 ### Client Readiness Checklist
 Code merged into Participating Clients


### PR DESCRIPTION
This pull request proposes block `12965000` for the mainnet activation of the London network upgrade. The ETA for this block should be between [13:00 UTC](https://www.timeanddate.com/date/dateadded.html?m1=7&d1=6&y1=2021&type=add&ay=&am=&aw=&ad=&h1=7&i1=35&s1=19&ah=&ai=&as=2500055&rec=) and [17:00 UTC](https://etherscan.io/block/countdown/12965000) on August 4, 2021. 

We had agreed on ACD116 to decide the block async and try and get client releases done for ACD117 (July 9). If we can roughly hit that timeline, then August 4th should provide enough time to advertise the client releases that are mainnet compatible, and allow infrastructure providers & node operators to upgrade. 