### PR TITLE
Remove more references to quilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ These version ranges are necessary because, at the time of writing, PyPy is only
 
 `eth1.0-specs` depends on a submodule that contains common tests that are run across all clients, so we need to clone the repo with the --recursive flag. Example:
 ```bash
-$ git clone --recursive https://github.com/quilt/eth1.0-specs.git
+$ git clone --recursive https://github.com/ethereum/eth1.0-specs.git
 ```
 
 Or, if you've already cloned the repository, you can fetch the submodules with:

--- a/src/ethereum/frontier/spec.py
+++ b/src/ethereum/frontier/spec.py
@@ -425,7 +425,7 @@ def check_proof_of_work(header: Header) -> bool:
     """
     # TODO: Implement this method once proof of work
     #  algorithm is implemented
-    #  https://github.com/quilt/eth1.0-specs/issues/43
+    #  https://github.com/ethereum/eth1.0-specs/issues/238
     raise NotImplementedError
 
 


### PR DESCRIPTION
### What was wrong?

Some links still pointed to the old quilt repository.

### How was it fixed?

Linked to Ethereum repository instead.

#### Cute Animal Picture

![PXL_20210526_215852571](https://user-images.githubusercontent.com/57262657/124801511-ec3a6a00-df24-11eb-9626-eea50bbc26d1.jpg)

