### PR TITLE
Add deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This repository contains various specification related to the Ethereum 1.0 chain, specifically the [pyspec](/src/eth1spec/spec.py), specifications for [network upgrades](/network-upgrades), and the [JSON RPC API](/json-rpc). 
+This repository contains various specification related to the Ethereum 1.0 chain, specifically the [pyspec](/src/eth1spec/spec.py), specifications for [network upgrades](/network-upgrades), and the (deprecated) [JSON-RPC API](/json-rpc). 
 
 ### Ethereum Protocol Releases
 

--- a/json-rpc/README.md
+++ b/json-rpc/README.md
@@ -1,5 +1,12 @@
 # Ethereum JSON-RPC Specification
 
+### Depreaction Notice
+**Please note, this spec will continue to be updated as a coordination point
+for the London hardfork. After the fork, this spec will be _deprecated_ in
+favor this repository: https://github.com/ethereum/eth1.0-apis**
+
+--
+
 [View the spec](https://playground.open-rpc.org/?uiSchema%5BappBar%5D%5Bui:splitView%5D=false&schemaUrl=https://raw.githubusercontent.com/ethereum/eth1.0-specs/master/json-rpc/spec.json&uiSchema%5BappBar%5D%5Bui:input%5D=false)
 
 The Ethereum JSON-RPC is a collection of methods that all clients implement.

--- a/json-rpc/README.md
+++ b/json-rpc/README.md
@@ -3,7 +3,7 @@
 ### Depreaction Notice
 **Please note, this spec will continue to be updated as a coordination point
 for the London hardfork. After the fork, this spec will be _deprecated_ in
-favor this repository: https://github.com/ethereum/eth1.0-apis**
+favor of this repository: https://github.com/ethereum/eth1.0-apis**
 
 --
 


### PR DESCRIPTION
### What was wrong?

Per https://github.com/ethereum/eth1.0-specs/issues/213, we'll be moving the JSON-RPC spec to a new repository.

### How was it fixed?

Added a deprecation notice.

#### Cute Animal Picture

![image](https://www.treehugger.com/thmb/pZ040BxzwC_CBQ4j48kAiwzqqJ4=/1417x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__mnn__images__2013__09__Psychrolutes_phrictus_blobfish-5041123eb1bf484f97c12c917770c40e.jpg)
