### PR TITLE
Implemented opcodes MSTORE, MSTORE8, MLOAD, MSIZE

### DIFF
--- a/src/ethereum/base_types.py
+++ b/src/ethereum/base_types.py
@@ -22,6 +22,7 @@ U255_MAX_VALUE = (2 ** 255) - 1
 U255_CEIL_VALUE = 2 ** 255
 U256_MAX_VALUE = (2 ** 256) - 1
 U256_CEIL_VALUE = 2 ** 256
+U8_MAX_VALUE = (2 ** 8) - 1
 
 
 class Uint(int):
@@ -36,12 +37,10 @@ class Uint(int):
         """
         Converts a sequence of bytes into an arbitrarily sized unsigned integer
         from its big endian representation.
-
         Parameters
         ----------
         buffer :
             Bytes to decode.
-
         Returns
         -------
         self : `Uint`
@@ -231,7 +230,6 @@ class Uint(int):
         """
         Converts this arbitrarily sized unsigned integer into its big endian
         representation with exactly 32 bytes.
-
         Returns
         -------
         big_endian : `Bytes32`
@@ -243,7 +241,6 @@ class Uint(int):
         """
         Converts this arbitrarily sized unsigned integer into its big endian
         representation.
-
         Returns
         -------
         big_endian : `Bytes`
@@ -269,12 +266,10 @@ class U256(int):
         """
         Converts a sequence of bytes into an arbitrarily sized unsigned integer
         from its big endian representation.
-
         Parameters
         ----------
         buffer :
             Bytes to decode.
-
         Returns
         -------
         self : `U256`
@@ -289,12 +284,10 @@ class U256(int):
     def from_signed(cls: Type, value: int) -> "U256":
         """
         Converts a signed number into a 256-bit unsigned integer.
-
         Parameters
         ----------
         value :
             Signed number
-
         Returns
         -------
         self : `U256`
@@ -599,7 +592,6 @@ class U256(int):
         """
         Converts this 256-bit unsigned integer into its big endian
         representation with exactly 32 bytes.
-
         Returns
         -------
         big_endian : `Bytes32`
@@ -611,7 +603,6 @@ class U256(int):
         """
         Converts this 256-bit unsigned integer into its big endian
         representation, omitting leading zero bytes.
-
         Returns
         -------
         big_endian : `Bytes`
@@ -624,7 +615,6 @@ class U256(int):
     def to_signed(self) -> int:
         """
         Converts this 256-bit unsigned integer into a signed integer.
-
         Returns
         -------
         signed_int : `int`

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -71,3 +71,38 @@ def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
     quadratic_cost = size_in_words ** 2 // 512
     total_gas_cost = linear_cost + quadratic_cost
     return U256(total_gas_cost)
+
+
+def calculate_gas_extend_memory(
+    memory: bytearray, start_position: Uint, size: U256
+) -> U256:
+    """
+    Calculates the gas amount to extend memory
+
+    Parameters
+    ----------
+    memory :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size:
+        Amount of bytes by which the memory needs to be extended.
+
+    Returns
+    -------
+    to_be_paid : `ethereum.base_types.U256`
+        returns `0` if size=0 or if the
+        size after extending memory is less than the size before extending
+        else it returns the amount that needs to be paid for extendinng memory.
+    """
+    if size == 0:
+        return U256(0)
+    memory_size = Uint(len(memory))
+    before_size = ceil32(memory_size)
+    after_size = ceil32(start_position + size)
+    if after_size <= before_size:
+        return U256(0)
+    already_paid = calculate_memory_gas_cost(before_size)
+    total_cost = calculate_memory_gas_cost(after_size)
+    to_be_paid = total_cost - already_paid
+    return to_be_paid

--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -11,8 +11,8 @@ Introduction
 
 EVM gas constants and calculators.
 """
-
-from ethereum.base_types import U256
+from ethereum.base_types import U256, Uint
+from ethereum.utils import ceil32
 
 from .error import OutOfGasError
 
@@ -24,6 +24,8 @@ GAS_STORAGE_CLEAR_REFUND = U256(15000)
 GAS_LOW = U256(5)
 GAS_MID = U256(8)
 GAS_EXPONENTIATION = U256(10)
+GAS_BASE = U256(2)
+GAS_MEMORY = U256(3)
 
 
 def subtract_gas(gas_left: U256, amount: U256) -> U256:
@@ -46,3 +48,26 @@ def subtract_gas(gas_left: U256, amount: U256) -> U256:
         raise OutOfGasError
 
     return gas_left - amount
+
+
+def calculate_memory_gas_cost(size_in_bytes: Uint) -> U256:
+    """
+    Calculates the gas cost for allocating memory
+    to the smallest multiple of 32 bytes,
+    such that the allocated size is at least as big as the given size.
+
+    Parameters
+    ----------
+    size_in_bytes :
+        The size of the data in bytes.
+
+    Returns
+    -------
+    total_gas_cost : `ethereum.base_types.U256`
+        The gas cost for storing data in memory.
+    """
+    size_in_words = ceil32(size_in_bytes) // 32
+    linear_cost = size_in_words * GAS_MEMORY
+    quadratic_cost = size_in_words ** 2 // 512
+    total_gas_cost = linear_cost + quadratic_cost
+    return U256(total_gas_cost)

--- a/src/ethereum/frontier/vm/instructions/__init__.py
+++ b/src/ethereum/frontier/vm/instructions/__init__.py
@@ -20,6 +20,7 @@ from . import arithmetic as arithmetic_instructions
 from . import bitwise as bitwise_instructions
 from . import comparison as comparison_instructions
 from . import control_flow as control_flow_instructions
+from . import memory as memory_instructions
 from . import stack as stack_instructions
 from . import storage as storage_instructions
 
@@ -134,6 +135,12 @@ class Ops(enum.Enum):
     SWAP15 = 0x9E
     SWAP16 = 0x9F
 
+    # Memory Operations
+    MLOAD = 0x51
+    MSTORE = 0x52
+    MSTORE8 = 0x53
+    MSIZE = 0x59
+
 
 op_implementation: Dict[Ops, Callable] = {
     Ops.STOP: control_flow_instructions.stop,
@@ -225,4 +232,8 @@ op_implementation: Dict[Ops, Callable] = {
     Ops.SWAP14: stack_instructions.swap14,
     Ops.SWAP15: stack_instructions.swap15,
     Ops.SWAP16: stack_instructions.swap16,
+    Ops.MLOAD: memory_instructions.mload,
+    Ops.MSTORE: memory_instructions.mstore,
+    Ops.MSTORE8: memory_instructions.mstore8,
+    Ops.MSIZE: memory_instructions.msize,
 }

--- a/src/ethereum/frontier/vm/instructions/memory.py
+++ b/src/ethereum/frontier/vm/instructions/memory.py
@@ -1,0 +1,126 @@
+"""
+Ethereum Virtual Machine (EVM) Memory Instructions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Implementations of the EVM Memory instructions.
+"""
+from ethereum.base_types import U8_MAX_VALUE, U256, Uint
+
+from .. import Evm
+from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..memory import (
+    extend_memory_and_subtract_gas,
+    memory_read_bytes,
+    memory_write,
+)
+from ..stack import pop, push
+
+
+def mstore(evm: Evm) -> None:
+    """
+    Stores a word to memory.
+    This also expands the memory, if the memory is
+    insufficient to store the word.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `2`.
+    OutOfGasError
+        If `evm.gas_left` is less than
+        `3` + gas needed to extend memeory.
+    """
+    # convert to Uint as start_position + size_to_extend can overflow.
+    start_position = Uint(pop(evm.stack))
+    value = pop(evm.stack).to_be_bytes32()
+    extend_memory_and_subtract_gas(evm, start_position, U256(32))
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    memory_write(evm.memory, start_position, value)
+
+
+def mstore8(evm: Evm) -> None:
+    """
+    Stores a byte to memory.
+    This also expands the memory, if the memory is
+    insufficient to store the word.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `2`.
+    OutOfGasError
+        If `evm.gas_left` is less than
+        `3` + gas needed to extend memory.
+    """
+    # convert to Uint as start_position + size_to_extend can overflow.
+    start_position = Uint(pop(evm.stack))
+    value = pop(evm.stack)
+    # make sure that value doesn't exceed 1 byte
+    normalized_bytes_value = (value & U8_MAX_VALUE).to_be_bytes()
+    extend_memory_and_subtract_gas(evm, start_position, U256(1))
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    memory_write(evm.memory, start_position, normalized_bytes_value)
+
+
+def mload(evm: Evm) -> None:
+    """
+    Load word from memory.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `1`.
+    OutOfGasError
+        If `evm.gas_left` is less than
+        `3` + gas needed to extend memory.
+    """
+    # convert to Uint as start_position + size_to_extend can overflow.
+    start_position = Uint(pop(evm.stack))
+    # extend memory and subtract gas for allocating 32 bytes of memory
+    extend_memory_and_subtract_gas(evm, start_position, U256(32))
+    value = U256.from_be_bytes(
+        memory_read_bytes(evm.memory, start_position, U256(32))
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+    push(evm.stack, value)
+
+
+def msize(evm: Evm) -> None:
+    """
+    Push the size of active memory in bytes onto the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    OutOfGasError
+        If `evm.gas_left` is less than `2`
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    memory_size = U256(len(evm.memory))
+    push(evm.stack, memory_size)

--- a/src/ethereum/frontier/vm/memory.py
+++ b/src/ethereum/frontier/vm/memory.py
@@ -11,24 +11,20 @@ Introduction
 
 EVM memory operations.
 """
-from ethereum.frontier.vm import Evm
 from ethereum.utils import ceil32
 
 from ...base_types import U256, Bytes, Uint
-from .gas import calculate_memory_gas_cost, subtract_gas
 
 
-def extend_memory_and_subtract_gas(
-    evm: Evm, start_position: Uint, size: U256
-) -> None:
+def extend_memory(memory: bytearray, start_position: Uint, size: U256) -> None:
     """
     Extends the size of the memory and
     substracts the gas amount to extend memory.
 
     Parameters
     ----------
-    evm :
-        The current EVM frame.
+    memory :
+        Memory contents of the EVM.
     start_position :
         Starting pointer to the memory.
     size :
@@ -36,16 +32,11 @@ def extend_memory_and_subtract_gas(
     """
     if size == 0:
         return None
-    memory = evm.memory
     memory_size = Uint(len(memory))
     before_size = ceil32(memory_size)
     after_size = ceil32(start_position + size)
     if after_size <= before_size:
         return None
-    already_paid = calculate_memory_gas_cost(before_size)
-    total_cost = calculate_memory_gas_cost(after_size)
-    to_be_paid = total_cost - already_paid
-    evm.gas_left = subtract_gas(evm.gas_left, to_be_paid)
     size_to_extend = after_size - memory_size
     memory += b"\x00" * size_to_extend
 
@@ -71,7 +62,7 @@ def memory_write(
 
 def memory_read_bytes(
     memory: bytearray, start_position: Uint, size: U256
-) -> Bytes:
+) -> bytearray:
     """
     Read bytes from memory.
 
@@ -89,4 +80,4 @@ def memory_read_bytes(
     data_bytes :
         Data read from memory.
     """
-    return Bytes(memory[start_position : start_position + size])
+    return memory[start_position : start_position + size]

--- a/src/ethereum/frontier/vm/memory.py
+++ b/src/ethereum/frontier/vm/memory.py
@@ -1,0 +1,92 @@
+"""
+Ethereum Virtual Machine (EVM) Memory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+EVM memory operations.
+"""
+from ethereum.frontier.vm import Evm
+from ethereum.utils import ceil32
+
+from ...base_types import U256, Bytes, Uint
+from .gas import calculate_memory_gas_cost, subtract_gas
+
+
+def extend_memory_and_subtract_gas(
+    evm: Evm, start_position: Uint, size: U256
+) -> None:
+    """
+    Extends the size of the memory and
+    substracts the gas amount to extend memory.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Amount of bytes by which the memory needs to be extended.
+    """
+    if size == 0:
+        return None
+    memory = evm.memory
+    memory_size = Uint(len(memory))
+    before_size = ceil32(memory_size)
+    after_size = ceil32(start_position + size)
+    if after_size <= before_size:
+        return None
+    already_paid = calculate_memory_gas_cost(before_size)
+    total_cost = calculate_memory_gas_cost(after_size)
+    to_be_paid = total_cost - already_paid
+    evm.gas_left = subtract_gas(evm.gas_left, to_be_paid)
+    size_to_extend = after_size - memory_size
+    memory += b"\x00" * size_to_extend
+
+
+def memory_write(
+    memory: bytearray, start_position: Uint, value: Bytes
+) -> None:
+    """
+    Writes to memory.
+
+    Parameters
+    ----------
+    memory :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    value :
+        Data to write to memory.
+    """
+    for idx, byte in enumerate(value):
+        memory[start_position + idx] = byte
+
+
+def memory_read_bytes(
+    memory: bytearray, start_position: Uint, size: U256
+) -> Bytes:
+    """
+    Read bytes from memory.
+
+    Parameters
+    ----------
+    memory :
+        Memory contents of the EVM.
+    start_position :
+        Starting pointer to the memory.
+    size :
+        Size of the data that needs to be read from `start_position`.
+
+    Returns
+    -------
+    data_bytes :
+        Data read from memory.
+    """
+    return Bytes(memory[start_position : start_position + size])

--- a/src/ethereum/utils.py
+++ b/src/ethereum/utils.py
@@ -11,6 +11,7 @@ Introduction
 
 Utility functions used in this application.
 """
+from ethereum.base_types import Uint
 
 
 def get_sign(value: int) -> int:
@@ -34,3 +35,27 @@ def get_sign(value: int) -> int:
         return 0
     else:
         return 1
+
+
+def ceil32(value: Uint) -> Uint:
+    """
+    Converts a unsigned integer to the next closest multiple of 32.
+
+    Parameters
+    ----------
+    value :
+        The value whose ceil32 is to be calculated.
+
+    Returns
+    -------
+    ceil32 : `ethereum.base_types.U256`
+        The same value if it's a perfect multiple of 32
+        else it returns the smallest multiple of 32
+        that is greater than `value`.
+    """
+    ceiling = Uint(32)
+    remainder = value % ceiling
+    if remainder == Uint(0):
+        return value
+    else:
+        return value + ceiling - remainder

--- a/tests/frontier/vm/test_memory_operations.py
+++ b/tests/frontier/vm/test_memory_operations.py
@@ -1,0 +1,92 @@
+from functools import partial
+
+import pytest
+
+from ethereum.frontier.vm.error import OutOfGasError
+from tests.frontier.vm.vm_test_helpers import run_test
+
+run_memory_vm_test = partial(
+    run_test,
+    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations/",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "mstore0.json",
+        "mstore1.json",
+    ],
+)
+def test_mstore(test_file: str) -> None:
+    run_memory_vm_test(test_file)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "mstoreMemExp.json",
+        "mloadOutOfGasError2.json",
+    ],
+)
+def test_mstore_error(test_file: str) -> None:
+    with pytest.raises(OutOfGasError):
+        run_memory_vm_test(test_file)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "mstore8_0.json",
+        "mstore8_1.json",
+        "mstore8WordToBigError.json",
+    ],
+)
+def test_mstore8(test_file: str) -> None:
+    run_memory_vm_test(test_file)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "mstore8MemExp.json",
+    ],
+)
+def test_mstore8_error(test_file: str) -> None:
+    with pytest.raises(OutOfGasError):
+        run_memory_vm_test(test_file)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "mloadError0.json",
+        "mloadError1.json",
+        "mstore_mload0.json",
+    ],
+)
+def test_mload(test_file: str) -> None:
+    run_memory_vm_test(test_file)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "mstore_mload0.json",
+    ],
+)
+def test_mstore_mload(test_file: str) -> None:
+    run_memory_vm_test(test_file)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "msize0.json",
+        "msize1.json",
+        "msize2.json",
+        "msize3.json",
+    ],
+)
+def test_msize(test_file: str) -> None:
+    run_memory_vm_test(test_file)

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -36,6 +36,7 @@ rlp
 trie
 U256
 U255
+U8
 secp256k1
 secp256k1n
 iadd
@@ -227,3 +228,6 @@ staticcall
 revert
 invalid
 selfdestruct
+
+ceil32
+rjust


### PR DESCRIPTION
### What was wrong?

Related to Issue #228
- Memory-related operations of the EVM weren't implemented. 

### How was it fixed?
- Implemented memory expansion calculator
- Implemented opcodes `MSTORE`, `MSTORE8`, `MLOAD`, `MSIZE`

## TODO
- [x] Check if more tests can be added.  
- [x] See if some validations need to be added before writing and reading from memory.
- [x] Move the helpers used in the tests to a common file so that they can be re-used.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/South_American_tapir_%28Tapirus_terrestris%29.JPG/1920px-South_American_tapir_%28Tapirus_terrestris%29.JPG)
