### PR TITLE
Require `gasPrice` field for both legacy and EIP-1559 transactions

### DIFF
--- a/json-rpc/spec.json
+++ b/json-rpc/spec.json
@@ -1716,6 +1716,11 @@
 									"maxPriorityFeePerGas"
 								],
 								"properties": {
+									"gasPrice": {
+										"title": "transactionGasPrice",
+										"type": "string",
+										"description": "The effective gas price paid by the sender in Wei. For transactions not yet mined, this value should be set equal to the max fee cap per gas. This field is DEPRECATED, please transition to using effectiveGasPrice in the Receipt object going forward."
+									},
 									"maxPriorityFeePerGas": {
 										"title": "transactionMaxPriorityFeePerGas",
 										"description": "Maximum fee per gas the sender is willing to pay to miners in wei",


### PR DESCRIPTION
### What was wrong?

As discussed in ACD 117, a lot of tooling relies on the `gasPrice` field of the `Transaction` object. Although this field doesn't make much sense with EIP-1559 transactions, for the sake of backwards compatibility we should continue supporting it. Please note that this field is **DEPRECATED** for EIP-1559 transactions, so developers should immediately begin transitioning to using the `effectiveGasPrice` field on the `Receipt` object.

### How was it fixed?

Return the `effectiveGasPrice` as the `gasPrice` field for EIP-1559 transactions. If the transaction has not yet been mined, clients should return the `maxFeeCapPerGas` value as `gasPrice`.

#### Cute Animal Picture

![](https://tr-images.condecdn.net/image/QMVB3wpapPd/crop/810/f/red-panda-gettyimages-1130384417.jpg)
