### PR TITLE
Add tool that enforces patch hygiene between hardforks.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
 
 [options]
 packages =
+    ethereum_spec_tools
     ethereum
     ethereum/frontier
     ethereum/frontier/vm
@@ -24,6 +25,10 @@ python_requires = >=3.7
 install_requires =
     pysha3>=1,<2
     coincurve>=15,<16
+
+[options.entry_points]
+console_scripts =
+    ethereum-spec-lint = ethereum_spec_tools.lint:main
 
 [options.extras_require]
 test =

--- a/src/ethereum/frontier/__init__.py
+++ b/src/ethereum/frontier/__init__.py
@@ -4,3 +4,5 @@ Ethereum Frontier Hardfork
 
 The first Ethereum hardfork.
 """
+
+MAINNET_FORK_BLOCK = 1

--- a/src/ethereum_spec_tools/__init__.py
+++ b/src/ethereum_spec_tools/__init__.py
@@ -1,0 +1,7 @@
+"""
+Ethereum Specification Tools
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Library of utilities and tools necessary for rendering (or otherwise working
+with) the Ethereum specifications.
+"""

--- a/src/ethereum_spec_tools/forks.py
+++ b/src/ethereum_spec_tools/forks.py
@@ -1,0 +1,86 @@
+"""
+Ethereum Forks
+^^^^^^^^^^^^^^
+
+Detects Python packages that specify Ethereum hardforks.
+"""
+
+import importlib
+import pkgutil
+from pkgutil import ModuleInfo
+from types import ModuleType
+from typing import Iterator, List, Optional, Type, TypeVar
+
+import ethereum
+
+H = TypeVar("H", bound="Hardfork")
+
+
+class Hardfork:
+    """
+    Metadata associated with an Ethereum hardfork.
+    """
+
+    mainnet_fork_block: int
+    path: Optional[str]
+    name: str
+
+    @classmethod
+    def discover(cls: Type[H]) -> List[H]:
+        """
+        Find packages which contain Ethereum hardfork specifications.
+        """
+        path = getattr(ethereum, "__path__", None)
+        if path is None:
+            raise ValueError("module `ethereum` has no path information")
+
+        modules = pkgutil.iter_modules(path, ethereum.__name__ + ".")
+        modules = (module for module in modules if module.ispkg)
+        forks: List[H] = []
+
+        for pkg in modules:
+            mod = importlib.import_module(pkg.name)
+            block = getattr(mod, "MAINNET_FORK_BLOCK", None)
+            path = getattr(mod, "__path__", None)
+
+            if block is None:
+                continue
+
+            forks.append(cls(block, path, mod.__name__))
+
+        forks.sort(key=lambda fork: fork.block)
+
+        return forks
+
+    def __init__(self, block: int, path: Optional[str], name: str) -> None:
+        self.block = block
+        self.path = path
+        self.name = name
+
+    def __repr__(self) -> str:
+        """
+        Return repr(self).
+        """
+        return (
+            self.__class__.__name__
+            + "("
+            + f"name={self.name!r}, "
+            + f"block={self.block}, "
+            + "..."
+            + ")"
+        )
+
+    def import_module(self) -> ModuleType:
+        """
+        Import and return the module containing this specification.
+        """
+        return importlib.import_module(self.name)
+
+    def iter_modules(self) -> Iterator[ModuleInfo]:
+        """
+        Iterate through the (sub-)modules describing this hardfork.
+        """
+        if self.path is None:
+            raise ValueError(f"cannot walk {self.name}, path is None")
+
+        return pkgutil.iter_modules(self.path, self.name + ".")

--- a/src/ethereum_spec_tools/lint.py
+++ b/src/ethereum_spec_tools/lint.py
@@ -1,0 +1,271 @@
+"""
+Lints
+^^^^^
+
+Checks specific to the Ethereum specification source code.
+"""
+
+import ast
+import importlib
+import inspect
+from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Generator, List, Optional, Sequence, Tuple
+
+from .forks import Hardfork
+
+
+def walk_sources(fork: Hardfork) -> Generator[Tuple[str, str], None, None]:
+    """
+    Import the modules specifying a hardfork, and retrieve their source code.
+    """
+    for mod_info in fork.iter_modules():
+        mod = importlib.import_module(mod_info.name)
+        source = inspect.getsource(mod)
+        name = mod.__name__
+        if name.startswith(fork.name):
+            name = name[len(fork.name) :]
+        yield (name, source)
+
+
+@dataclass
+class Diagnostic:
+    """
+    A diagnostic message generated while checking the specifications.
+    """
+
+    message: str
+
+
+class Lint(metaclass=ABCMeta):
+    """
+    A single check which may be performed against the specifications.
+    """
+
+    @abstractmethod
+    def lint(
+        self, forks: List[Hardfork], position: int
+    ) -> Sequence[Diagnostic]:
+        """
+        Runs the check against the given forks, at the given position.
+
+        Parameters
+        ----------
+        forks :
+            All known hardforks.
+        position :
+            The particular hardfork to lint.
+        """
+
+
+class PatchHygieneVisitor(ast.NodeVisitor):
+    """
+    Visits nodes in a syntax tree and collects functions, classes, and
+    assignments.
+    """
+
+    path: List[str]
+    _items: "OrderedDict[str, None]"
+    in_assign: int
+
+    def __init__(self) -> None:
+        self.path = []
+        self._items = OrderedDict()
+        self.in_assign = 0
+
+    def _insert(self, item: str) -> None:
+        item = ".".join(self.path + [item])
+        if item in self._items:
+            raise ValueError(f"duplicate path {item}")
+        self._items[item] = None
+
+    @property
+    def items(self) -> Sequence[str]:
+        """
+        Sequence of all identifiers found while visiting the source.
+        """
+        return list(self._items.keys())
+
+    def visit_AsyncFunctionDef(self, function: ast.AsyncFunctionDef) -> None:
+        """
+        Visit an asynchronous function.
+        """
+        self._insert(function.name)
+        # Explicitly don't visit the children of functions.
+
+    def visit_FunctionDef(self, function: ast.FunctionDef) -> None:
+        """
+        Visit a function.
+        """
+        self._insert(function.name)
+        # Explicitly don't visit the children of functions.
+
+    def visit_ClassDef(self, klass: ast.ClassDef) -> None:
+        """
+        Visit a class.
+        """
+        self._insert(klass.name)
+        self.path.append(klass.name)
+        self.generic_visit(klass)
+        got = self.path.pop()
+        assert klass.name == got
+
+    def visit_Assign(self, assign: ast.Assign) -> None:
+        """
+        Visit an assignment.
+        """
+        self.in_assign += 1
+        for target in assign.targets:
+            self.visit(target)
+        self.in_assign -= 1
+        self.visit(assign.value)
+
+    def visit_AnnAssign(self, assign: ast.AnnAssign) -> None:
+        """
+        Visit an annotated assignment.
+        """
+        self.in_assign += 1
+        self.visit(assign.target)
+        self.in_assign -= 1
+        self.visit(assign.annotation)
+        if assign.value is not None:
+            self.visit(assign.value)
+
+    def visit_Name(self, identifier: ast.Name) -> None:
+        """
+        Visit an identifier.
+        """
+        if self.in_assign > 0:
+            self._insert(identifier.id)
+
+
+class PatchHygiene(Lint):
+    """
+    Ensures that the order of identifiers between each hardfork is consistent.
+    """
+
+    def lint(
+        self, forks: List[Hardfork], position: int
+    ) -> Sequence[Diagnostic]:
+        """
+        Walks the sources for each hardfork and emits Diagnostic messages.
+        """
+        if position == 0:
+            # Nothing to compare against!
+            return []
+
+        all_previous = dict(walk_sources(forks[position - 1]))
+        all_current = dict(walk_sources(forks[position]))
+
+        items = (
+            (k, v, all_previous.get(k, None)) for (k, v) in all_current.items()
+        )
+
+        diagnostics: List[Diagnostic] = []
+        for (name, current, previous) in items:
+            diagnostics += self.compare(name, current, previous)
+
+        return diagnostics
+
+    def compare(
+        self, name: str, current_source: str, previous_source: Optional[str]
+    ) -> List[Diagnostic]:
+        """
+        Compares two strings containing Python source and emits diagnostic
+        messages if any identifiers have changed relative positions.
+        """
+        if previous_source is None:
+            # Entire file is new, so nothing to compare!
+            return []
+
+        current_nodes = self.parse(current_source)
+        previous_nodes = {
+            item: idx for (idx, item) in enumerate(self.parse(previous_source))
+        }
+
+        diagnostics: List[Diagnostic] = []
+        maximum = None
+
+        for item in current_nodes:
+            previous_position = previous_nodes.get(item)
+            if previous_position is None:
+                continue
+
+            if maximum is None or previous_position > maximum:
+                maximum = previous_position
+            elif previous_position <= maximum:
+                diagnostic = Diagnostic(
+                    message=(
+                        f"the item `{item}` in `{name}` has changed "
+                        "relative positions"
+                    )
+                )
+                diagnostics.append(diagnostic)
+
+        return diagnostics
+
+    def parse(self, source: str) -> Sequence[str]:
+        """
+        Walks the source string and extracts an ordered sequence of
+        identifiers.
+        """
+        parsed = ast.parse(source)
+        visitor = PatchHygieneVisitor()
+        visitor.visit(parsed)
+        return visitor.items
+
+
+class Linter:
+    """
+    Checks the specification for style guideline violations.
+    """
+
+    ALL_LINTS: List[Lint] = [
+        PatchHygiene(),
+    ]
+
+    lints: Sequence[Lint]
+
+    def __init__(self, lints: Sequence[Lint] = ALL_LINTS) -> None:
+        self.lints = lints
+
+    def run(self) -> int:
+        """
+        Runs all enabled lints.
+        """
+        count = 0
+        hardforks = Hardfork.discover()
+
+        for lint in self.lints:
+            diagnostics: List[Diagnostic] = []
+            for hardfork in range(0, len(hardforks)):
+                diagnostics += lint.lint(hardforks, hardfork)
+
+            if diagnostics:
+                count += len(diagnostics)
+                print(
+                    f"{hardforks[hardfork].name} - {lint.__class__.__name__}:"
+                )
+                for diagnostic in diagnostics:
+                    print("\t", diagnostic.message)
+
+        if count > 0:
+            print("Total diagnostics:", count)
+
+        return 1 if count > 0 else 0
+
+
+def main() -> int:
+    """
+    `ethereum-spec-lint` checks for style and formatting issues specific to the
+    Ethereum specification.
+    """
+    linter = Linter()
+    return linter.run()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,171 @@
+import ast
+from textwrap import dedent
+
+from ethereum_spec_tools.lint import (
+    Diagnostic,
+    PatchHygiene,
+    PatchHygieneVisitor,
+)
+
+
+def test_visitor_assignment_simple() -> None:
+    src = """
+    variable0 = 67
+    variable1 = 68
+    """
+    tree = ast.parse(dedent(src))
+    visitor = PatchHygieneVisitor()
+    visitor.visit(tree)
+    items = visitor.items
+    assert items == ["variable0", "variable1"]
+
+
+def test_visitor_assignment_tuple() -> None:
+    src = """
+    (variable0, variable1) = (67, 68)
+    """
+    tree = ast.parse(dedent(src))
+    visitor = PatchHygieneVisitor()
+    visitor.visit(tree)
+    items = visitor.items
+    assert items == ["variable0", "variable1"]
+
+
+def test_visitor_class() -> None:
+    src = """
+    class Foo:
+        some_field: int
+        some_assignment = 3
+
+        def some_function(self):
+            invisible = 3
+    """
+    tree = ast.parse(dedent(src))
+    visitor = PatchHygieneVisitor()
+    visitor.visit(tree)
+    items = visitor.items
+    assert items == [
+        "Foo",
+        "Foo.some_field",
+        "Foo.some_assignment",
+        "Foo.some_function",
+    ]
+
+
+def test_visitor_class_nested() -> None:
+    src = """
+    class Foo:
+        class Bar:
+            some_field = 4
+    """
+    tree = ast.parse(dedent(src))
+    visitor = PatchHygieneVisitor()
+    visitor.visit(tree)
+    items = visitor.items
+    assert items == [
+        "Foo",
+        "Foo.Bar",
+        "Foo.Bar.some_field",
+    ]
+
+
+def test_patch_hygiene_compare_new_module() -> None:
+    old = None
+    new = ""
+
+    lint = PatchHygiene()
+    diagnostics = lint.compare("new_module", new, old)
+    assert diagnostics == []
+
+
+def test_patch_hygiene_compare_both_empty() -> None:
+    old = ""
+    new = ""
+
+    lint = PatchHygiene()
+    diagnostics = lint.compare("empty", new, old)
+    assert diagnostics == []
+
+
+def test_patch_hygiene_compare_add_new_assign() -> None:
+    old = ""
+    new = "SOME_CONSTANT = 3"
+
+    lint = PatchHygiene()
+    diagnostics = lint.compare("new_assign", new, old)
+    assert diagnostics == []
+
+
+def test_patch_hygiene_compare_remove_assign() -> None:
+    old = "SOME_CONSTANT = 3"
+    new = ""
+
+    lint = PatchHygiene()
+    diagnostics = lint.compare("remove_assign", new, old)
+    assert diagnostics == []
+
+
+def test_patch_hygiene_compare_reorder_assign() -> None:
+    old = """
+    FIRST_CONSTANT = 3
+    SECOND_CONSTANT = 3
+    """
+
+    new = """
+    SECOND_CONSTANT = 3
+    FIRST_CONSTANT = 3
+    """
+
+    lint = PatchHygiene()
+    diagnostics = lint.compare("reorder_assign", dedent(new), dedent(old))
+    assert diagnostics == [
+        Diagnostic(
+            message=(
+                "the item `FIRST_CONSTANT` in `reorder_assign` has changed "
+                "relative positions"
+            )
+        )
+    ]
+
+
+def test_patch_hygiene_compare_add_between_assign() -> None:
+    old = """
+    FIRST_CONSTANT = 3
+    SECOND_CONSTANT = 3
+    """
+
+    new = """
+    FIRST_CONSTANT = 3
+    NEW_CONSTANT = 3
+    SECOND_CONSTANT = 3
+    """
+
+    lint = PatchHygiene()
+    diagnostics = lint.compare("add_between_assign", dedent(new), dedent(old))
+    assert diagnostics == []
+
+
+def test_patch_hygiene_compare_reorder_between_assign() -> None:
+    old = """
+    FIRST_CONSTANT = 3
+    SECOND_CONSTANT = 3
+    """
+
+    new = """
+    SECOND_CONSTANT = 3
+    NEW_CONSTANT = 3
+    FIRST_CONSTANT = 3
+    """
+
+    lint = PatchHygiene()
+    diagnostics = lint.compare(
+        "reorder_between_assign", dedent(new), dedent(old)
+    )
+    assert diagnostics == [
+        Diagnostic(
+            message=(
+                "the item `FIRST_CONSTANT` in `reorder_between_assign` has "
+                "changed relative positions"
+            )
+        )
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands =
     flake8 src tests setup.py
     mypy src tests setup.py --exclude "tests/fixtures/*"
     pytest --cov=ethereum --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" --ignore-glob='tests/fixtures/*'
+    ethereum-spec-lint
 
 [testenv:pypy3]
 extras =
@@ -20,6 +21,7 @@ commands =
     isort src tests setup.py --check --diff --skip-glob "tests/fixtures/*"
     flake8 src tests setup.py
     pytest --ignore-glob='tests/fixtures/*'
+    ethereum-spec-lint
 
 [testenv:doc]
 basepython = python3

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,3 +1,6 @@
+AnnAssign
+AsyncFunctionDef
+ClassDef
 radd
 Hash64
 Bytes20
@@ -12,15 +15,21 @@ endian
 eth
 ethereum
 evm
+getsource
 Hash32
 hasher
+hardfork
+hardforks
 idx
 keccak
 keccak256
 keccak512
+linter
+mainnet
 memoization
 merkle
 merkleize
+metaclass
 ommers
 patricialize
 rlp
@@ -30,6 +39,7 @@ U255
 secp256k1
 secp256k1n
 iadd
+ispkg
 isub
 rsub
 imul
@@ -41,6 +51,7 @@ itruediv
 rfloordiv
 ifloordiv
 floordiv
+FunctionDef
 rmod
 imod
 mod


### PR DESCRIPTION
### What was wrong?

Ideally we want to support meaningful diffs between different hardforks, and generating meaningful diffs is a difficult problem.

### How was it fixed?

This tool scans the sources of all hardforks and ensures that the relative order of functions, classes, and constants doesn't change between forks.

Hopefully this'll give us enough similarity for `rstdiff` to work its magic.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/PdnlOAk.jpg)
