### PR TITLE
Implement EVM environmental opcodes

### DIFF
--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -16,6 +16,7 @@ from ethereum.utils import ceil32
 
 from .error import OutOfGasError
 
+GAS_EXT = U256(20)
 GAS_VERY_LOW = U256(3)
 GAS_SLOAD = U256(50)
 GAS_STORAGE_SET = U256(20000)
@@ -28,6 +29,7 @@ GAS_BASE = U256(2)
 GAS_MEMORY = U256(3)
 GAS_KECCAK256 = U256(30)
 GAS_KECCAK256_WORD = U256(6)
+GAS_COPY = U256(3)
 
 
 def subtract_gas(gas_left: U256, amount: U256) -> U256:

--- a/src/ethereum/frontier/vm/instructions/__init__.py
+++ b/src/ethereum/frontier/vm/instructions/__init__.py
@@ -20,6 +20,7 @@ from . import arithmetic as arithmetic_instructions
 from . import bitwise as bitwise_instructions
 from . import comparison as comparison_instructions
 from . import control_flow as control_flow_instructions
+from . import environment as environment_instructions
 from . import keccak as keccak_instructions
 from . import memory as memory_instructions
 from . import stack as stack_instructions
@@ -58,6 +59,21 @@ class Ops(enum.Enum):
     XOR = 0x18
     NOT = 0x19
     BYTE = 0x1A
+
+    # Environmental Ops
+    ADDRESS = 0x30
+    BALANCE = 0x31
+    ORIGIN = 0x32
+    CALLER = 0x33
+    CALLVALUE = 0x34
+    CALLDATALOAD = 0x35
+    CALLDATASIZE = 0x36
+    CALLDATACOPY = 0x37
+    CODESIZE = 0x38
+    CODECOPY = 0x39
+    GASPRICE = 0x3A
+    EXTCODESIZE = 0x3B
+    EXTCODECOPY = 0x3C
 
     # Computation Ops
     STOP = 0x00
@@ -177,6 +193,19 @@ op_implementation: Dict[Ops, Callable] = {
     Ops.MSTORE: memory_instructions.mstore,
     Ops.MSTORE8: memory_instructions.mstore8,
     Ops.MSIZE: memory_instructions.msize,
+    Ops.ADDRESS: environment_instructions.address,
+    Ops.BALANCE: environment_instructions.balance,
+    Ops.ORIGIN: environment_instructions.origin,
+    Ops.CALLER: environment_instructions.caller,
+    Ops.CALLVALUE: environment_instructions.callvalue,
+    Ops.CALLDATALOAD: environment_instructions.calldataload,
+    Ops.CALLDATASIZE: environment_instructions.calldatasize,
+    Ops.CALLDATACOPY: environment_instructions.calldatacopy,
+    Ops.CODESIZE: environment_instructions.codesize,
+    Ops.CODECOPY: environment_instructions.codecopy,
+    Ops.GASPRICE: environment_instructions.gasprice,
+    Ops.EXTCODESIZE: environment_instructions.extcodesize,
+    Ops.SSTORE: storage_instructions.sstore,
     Ops.PUSH1: stack_instructions.push1,
     Ops.PUSH2: stack_instructions.push2,
     Ops.PUSH3: stack_instructions.push3,

--- a/src/ethereum/frontier/vm/instructions/environment.py
+++ b/src/ethereum/frontier/vm/instructions/environment.py
@@ -1,0 +1,393 @@
+"""
+Ethereum Virtual Machine (EVM) Environmental Instructions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Implementations of the EVM environment related instructions.
+"""
+
+from ethereum.base_types import U256, Uint
+from ethereum.frontier.vm.memory import extend_memory, memory_write
+from ethereum.utils import ceil32
+
+from .. import Evm
+from ..gas import (
+    GAS_BASE,
+    GAS_COPY,
+    GAS_EXT,
+    GAS_VERY_LOW,
+    calculate_gas_extend_memory,
+    subtract_gas,
+)
+from ..stack import pop, push
+
+# Address can be only 20 bytes
+MAX_ADDRESS_BYTES = 20
+
+
+def address(evm: Evm) -> None:
+    """
+    Pushes the address of the current executing account to the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    OutOfGasError
+        If `evm.gas_left` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    push(evm.stack, U256.from_be_bytes(evm.current))
+
+
+def balance(evm: Evm) -> None:
+    """
+    Pushes the balance of the given account onto the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `1`.
+    OutOfGasError
+        If `evm.gas_left` is less than `20`.
+    """
+    # TODO: There are no test cases against this function. Need to write
+    # custom test cases.
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXT)
+
+    address = pop(evm.stack).to_be_bytes32()
+    address = address[-MAX_ADDRESS_BYTES:]
+
+    account_state = evm.env.state.get(address, None)
+    if account_state is None:
+        balance = U256(0)
+    else:
+        balance = U256(account_state.balance)
+
+    push(evm.stack, balance)
+
+
+def origin(evm: Evm) -> None:
+    """
+    Pushes the address of the original transaction sender to the stack.
+    The origin address can only be an EOA.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    OutOfGasError
+        If `evm.gas_left` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    push(evm.stack, U256.from_be_bytes(evm.env.origin))
+
+
+def caller(evm: Evm) -> None:
+    """
+    Pushes the address of the caller onto the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    OutOfGasError
+        If `evm.gas_left` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    push(evm.stack, U256.from_be_bytes(evm.caller))
+
+
+def callvalue(evm: Evm) -> None:
+    """
+    Push the value (in wei) sent with the call onto the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    OutOfGasError
+        If `evm.gas_left` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    push(evm.stack, evm.value)
+
+
+def calldataload(evm: Evm) -> None:
+    """
+    Push a word (32 bytes) of the input data belonging to the current
+    environment onto the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `1`.
+    OutOfGasError
+        If `evm.gas_left` is less than `3`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+
+    # Converting start_index to Uint from U256 as start_index + 32 can
+    # overflow U256.
+    start_index = Uint(pop(evm.stack))
+    value = evm.data[start_index : start_index + 32]
+    # Right pad with 0 so that there are overall 32 bytes.
+    value = value.ljust(32, b"\x00")
+
+    push(evm.stack, U256.from_be_bytes(value))
+
+
+def calldatasize(evm: Evm) -> None:
+    """
+    Push the size of input data in current environment onto the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    OutOfGasError
+        If `evm.gas_left` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    push(evm.stack, U256(len(evm.data)))
+
+
+def calldatacopy(evm: Evm) -> None:
+    """
+    Copy a portion of the input data in current environment to memory.
+
+    This will also expand the memory, in case that the memory is insufficient
+    to store the data.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `3`.
+    """
+    # Converting below to Uint as though the start indices may belong to U256,
+    # the ending indices may overflow U256.
+    memory_start_index = Uint(pop(evm.stack))
+    data_start_index = Uint(pop(evm.stack))
+    size = pop(evm.stack)
+
+    words = ceil32(Uint(size)) // 32
+    gas_cost = (
+        GAS_VERY_LOW
+        + (GAS_COPY * words)
+        + calculate_gas_extend_memory(evm.memory, memory_start_index, size)
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+
+    if size == 0:
+        return
+
+    extend_memory(evm.memory, memory_start_index, size)
+
+    value = evm.data[data_start_index : data_start_index + size]
+    # But it is possible that data_start_index + size won't exist in evm.data
+    # in which case we need to right pad the above obtained bytes with 0.
+    value = value.ljust(size, b"\x00")
+
+    memory_write(evm.memory, memory_start_index, value)
+
+
+def codesize(evm: Evm) -> None:
+    """
+    Push the size of code running in current environment onto the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    OutOfGasError
+        If `evm.gas_left` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    push(evm.stack, U256(len(evm.code)))
+
+
+def codecopy(evm: Evm) -> None:
+    """
+    Copy a portion of the code in current environment to memory.
+
+    This will also expand the memory, in case that the memory is insufficient
+    to store the data.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `3`.
+    """
+    # Converting below to Uint as though the start indices may belong to U256,
+    # the ending indices may not belong to U256.
+    memory_start_index = Uint(pop(evm.stack))
+    code_start_index = Uint(pop(evm.stack))
+    size = pop(evm.stack)
+
+    words = ceil32(Uint(size)) // 32
+    gas_cost = (
+        GAS_VERY_LOW
+        + (GAS_COPY * words)
+        + calculate_gas_extend_memory(evm.memory, memory_start_index, size)
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+
+    if size == 0:
+        return
+
+    extend_memory(evm.memory, memory_start_index, size)
+
+    value = evm.code[code_start_index : code_start_index + size]
+    # But it is possible that code_start_index + size - 1 won't exist in
+    # evm.code in which case we need to right pad the above obtained bytes
+    # with 0.
+    value = value.ljust(size, b"\x00")
+
+    memory_write(evm.memory, memory_start_index, value)
+
+
+def gasprice(evm: Evm) -> None:
+    """
+    Push the gas price used in current environment onto the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    OutOfGasError
+        If `evm.gas_left` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    push(evm.stack, evm.env.gas_price)
+
+
+def extcodesize(evm: Evm) -> None:
+    """
+    Push the code size of a given account onto the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `1`.
+    OutOfGasError
+        If `evm.gas_left` is less than `20`.
+    """
+    # TODO: There are no test cases against this function. Need to write
+    # custom test cases.
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_EXT)
+
+    address = pop(evm.stack).to_be_bytes32()
+    address = address[-MAX_ADDRESS_BYTES:]
+
+    account_state = evm.env.state.get(address, None)
+    if account_state is None:
+        codesize = U256(0)
+    else:
+        codesize = U256(len(evm.env.state[address].code))
+
+    push(evm.stack, codesize)
+
+
+def extcodecopy(evm: Evm) -> None:
+    """
+    Copy a portion of an account's code to memory.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `4`.
+    """
+    # TODO: There are no test cases against this function. Need to write
+    # custom test cases.
+
+    address = pop(evm.stack).to_be_bytes32()
+    address = address[-MAX_ADDRESS_BYTES:]
+
+    memory_start_index = Uint(pop(evm.stack))
+    code_start_index = Uint(pop(evm.stack))
+    size = pop(evm.stack)
+
+    words = ceil32(Uint(size)) // 32
+    gas_cost = (
+        GAS_EXT
+        + (GAS_COPY * words)
+        + calculate_gas_extend_memory(evm.memory, memory_start_index, size)
+    )
+    evm.gas_left = subtract_gas(evm.gas_left, gas_cost)
+
+    if size == 0:
+        return
+
+    # Get code belonging to another account. In case the other account
+    # doesn't exist in the state yet, default to an empty byte code.
+    account_state = evm.env.state.get(address, None)
+    if account_state is None:
+        code = b""
+    else:
+        code = account_state.code
+
+    extend_memory(evm.memory, memory_start_index, size)
+
+    value = code[code_start_index : code_start_index + size]
+    # But it is possible that code_start_index + size won't exist in evm.code
+    # in which case we need to right pad the above obtained bytes with 0.
+    value = value.ljust(size, b"\x00")
+
+    memory_write(evm.memory, memory_start_index, value)

--- a/tests/frontier/vm/test_environmental_operations.py
+++ b/tests/frontier/vm/test_environmental_operations.py
@@ -1,0 +1,105 @@
+from functools import partial
+
+import pytest
+
+from ethereum.frontier.vm.error import StackUnderflowError
+from tests.frontier.vm.vm_test_helpers import run_test
+
+run_environmental_vm_test = partial(
+    run_test,
+    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmEnvironmentalInfo",
+)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "address0.json",
+        "address1.json",
+    ],
+)
+def test_address(test_file: str) -> None:
+    run_environmental_vm_test(test_file)
+
+
+def test_origin() -> None:
+    run_environmental_vm_test("origin.json")
+
+
+def test_caller() -> None:
+    run_environmental_vm_test("caller.json")
+
+
+def test_callvalue() -> None:
+    run_environmental_vm_test("callvalue.json")
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "calldataload0.json",
+        "calldataload1.json",
+        "calldataload2.json",
+        "calldataload_BigOffset.json",
+        "calldataloadSizeTooHigh.json",
+        "calldataloadSizeTooHighPartial.json",
+    ],
+)
+def test_calldataload(test_file: str) -> None:
+    run_environmental_vm_test(test_file)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "calldatasize0.json",
+        "calldatasize1.json",
+        "calldatasize2.json",
+    ],
+)
+def test_calldatasize(test_file: str) -> None:
+    run_environmental_vm_test(test_file)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "calldatacopy0.json",
+        "calldatacopy1.json",
+        "calldatacopy2.json",
+        "calldatacopyZeroMemExpansion.json",
+        "calldatacopy_DataIndexTooHigh.json",
+        "calldatacopy_DataIndexTooHigh2.json",
+        # TODO: Run below test case once the JUMP opcode is implemented
+        # "calldatacopy_sec.json",
+        # TODO: Run the above test cases which end with `_return.json` once
+        # RETURN opcode is implemented.
+    ],
+)
+def test_calldatacopy(test_file: str) -> None:
+    run_environmental_vm_test(test_file)
+
+
+def test_calldatacopy_fails_stack_underflow_error() -> None:
+    with pytest.raises(StackUnderflowError):
+        run_environmental_vm_test("calldatacopyUnderFlow.json")
+
+
+def test_codesize() -> None:
+    run_environmental_vm_test("codesize.json")
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "codecopy0.json",
+        "codecopyZeroMemExpansion.json",
+        "codecopy_DataIndexTooHigh.json",
+    ],
+)
+def test_codecopy(test_file: str) -> None:
+    run_environmental_vm_test(test_file)
+
+
+def test_gasprice() -> None:
+    run_environmental_vm_test("gasprice.json")

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -231,3 +231,4 @@ selfdestruct
 
 ceil32
 rjust
+ljust


### PR DESCRIPTION
### What was wrong?
Environment related opcodes weren't implemented.
Related to Issue #254 

### How was it fixed?
Following frontier yellowpaper

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pbs.twimg.com/profile_images/521554275713830913/TBY5IslL.jpeg)
