### PR TITLE
Implement EVM memory instructions

### DIFF
--- a/src/ethereum/frontier/vm/gas.py
+++ b/src/ethereum/frontier/vm/gas.py
@@ -16,7 +16,9 @@ from ethereum.base_types import U256
 
 from .error import OutOfGasError
 
+GAS_BASE = U256(2)
 GAS_VERY_LOW = U256(3)
+GAS_MEMORY = U256(3)
 GAS_STORAGE_SET = U256(20000)
 GAS_STORAGE_UPDATE = U256(5000)
 GAS_STORAGE_CLEAR_REFUND = U256(15000)

--- a/src/ethereum/frontier/vm/instructions/__init__.py
+++ b/src/ethereum/frontier/vm/instructions/__init__.py
@@ -18,6 +18,7 @@ from typing import Callable, Dict
 
 from . import arithmetic as arithmetic_instructions
 from . import control_flow as control_flow_instructions
+from . import memory as memory_instructions
 from . import stack as stack_instructions
 from . import storage as storage_instructions
 
@@ -45,6 +46,15 @@ class Ops(enum.Enum):
 
     # Storage Ops
     SSTORE = 0x55
+
+    # Memory Ops
+    MLOAD = 0x51
+    MSTORE = 0x52
+    MSTORE8 = 0x53
+    MSIZE = 0x59
+
+    # Pop operation
+    POP = 0x50
 
     # Push Operations
     PUSH1 = 0x60
@@ -130,7 +140,12 @@ op_implementation: Dict[Ops, Callable] = {
     Ops.MULMOD: arithmetic_instructions.mulmod,
     Ops.EXP: arithmetic_instructions.exp,
     Ops.SIGNEXTEND: arithmetic_instructions.signextend,
+    Ops.MLOAD: memory_instructions.mload,
+    Ops.MSTORE: memory_instructions.mstore,
+    Ops.MSTORE8: memory_instructions.mstore8,
+    Ops.MSIZE: memory_instructions.msize,
     Ops.SSTORE: storage_instructions.sstore,
+    Ops.POP: stack_instructions.pop_opcode,
     Ops.PUSH1: stack_instructions.push1,
     Ops.PUSH2: stack_instructions.push2,
     Ops.PUSH3: stack_instructions.push3,

--- a/src/ethereum/frontier/vm/instructions/memory.py
+++ b/src/ethereum/frontier/vm/instructions/memory.py
@@ -1,0 +1,140 @@
+"""
+Ethereum Virtual Machine (EVM) Memory Instructions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Implementations of the EVM memory instructions.
+"""
+
+from ethereum.base_types import U256, Uint
+from ethereum.utils import get_ceil32
+
+from .. import Evm
+from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..memory import expand_memory
+from ..stack import pop, push
+
+MAX_BYTE_VALUE = 0xFF
+
+
+def mload(evm: Evm) -> None:
+    """
+    Load word (32 bytes) from memory and push it onto the stack.
+
+    This also expands the memory, incase the memory is insufficient to access
+    the word's memory location.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `1`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+
+    # Converting memory_start_index to Uint and memory_end_index can
+    # overflow U256.
+    memory_start_index = Uint(pop(evm.stack))
+    required_memory_size = memory_start_index + 32
+
+    if len(evm.memory) < required_memory_size:
+        # The required memory indices are not present. Hence we need to
+        # expand the memory and reduce the corresponding gas for that.
+        expand_memory(evm, memory_size=get_ceil32(required_memory_size))
+
+    word = evm.memory[memory_start_index : memory_start_index + 32]
+    push(evm.stack, U256.from_be_bytes(word))
+
+
+def mstore(evm: Evm) -> None:
+    """
+    Save word (32 bytes) to memory.
+
+    This also expands the memory in multiples of words, if the memory is
+    insufficient to store the word.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+
+    # Converting memory_start_index to Uint and memory_end_index can
+    # overflow U256.
+    memory_start_index = Uint(pop(evm.stack))
+    required_memory_size = memory_start_index + 32
+    word = pop(evm.stack).to_be_bytes32()
+
+    if len(evm.memory) < required_memory_size:
+        # The required memory indices are not present. Hence we need to
+        # expand the memory and reduce the corresponding gas for that.
+        expand_memory(evm, memory_size=get_ceil32(required_memory_size))
+
+    evm.memory[memory_start_index : memory_start_index + 32] = word
+
+
+def mstore8(evm: Evm) -> None:
+    """
+    Save a byte to memory.
+
+    This also expands the memory, if the memory is insufficient to store
+    the byte.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_VERY_LOW)
+
+    # The index in memory at which the byte would be written.
+    memory_index = Uint(pop(evm.stack))
+    required_memory_size = memory_index + 1
+    # Obtain the least significant byte from the word.
+    byte = pop(evm.stack) & MAX_BYTE_VALUE
+
+    if len(evm.memory) < required_memory_size:
+        # The required memory indices are not present. Hence we need to
+        # expand the memory and reduce the corresponding gas for that.
+        expand_memory(evm, memory_size=get_ceil32(required_memory_size))
+
+    evm.memory[memory_index] = byte
+
+
+def msize(evm: Evm) -> None:
+    """
+    Get the size of active memory in bytes. Also pushes this onto the stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    OutOfGasError
+        If `evm.gas_left` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    push(evm.stack, U256(len(evm.memory)))

--- a/src/ethereum/frontier/vm/instructions/stack.py
+++ b/src/ethereum/frontier/vm/instructions/stack.py
@@ -17,8 +17,28 @@ from functools import partial
 from ethereum.base_types import U256
 
 from .. import Evm
-from ..gas import GAS_VERY_LOW, subtract_gas
-from ..stack import push
+from ..gas import GAS_BASE, GAS_VERY_LOW, subtract_gas
+from ..stack import pop, push
+
+
+def pop_opcode(evm: Evm) -> None:
+    """
+    Remove item from stack.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+
+    Raises
+    ------
+    StackUnderflowError
+        If `len(stack)` is less than `1`.
+    OutOfGasError
+        If `evm.gas_left` is less than `2`.
+    """
+    evm.gas_left = subtract_gas(evm.gas_left, GAS_BASE)
+    pop(evm.stack)
 
 
 def push_n(evm: Evm, num_bytes: int) -> None:

--- a/src/ethereum/frontier/vm/memory.py
+++ b/src/ethereum/frontier/vm/memory.py
@@ -1,0 +1,92 @@
+"""
+Ethereum Virtual Machine (EVM) Memory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Implementation of the EVM memory expansion related operations.
+"""
+
+from typing import cast
+
+from ethereum.base_types import U256
+
+from . import Evm
+from .gas import GAS_MEMORY, subtract_gas
+
+
+def get_words(memory_size: int) -> int:
+    """
+    Obtain the number of words (32 bytes) which is present in the memory,
+    based on the memory size. Memory size is the number of bytes present in
+    memory.
+
+    If the memory size is not a perfect multiple of 32 bytes, then the number
+    of words in memory is considered as the ceil32 of memory size.
+
+    Parameters
+    ----------
+    memory_size :
+        Number of bytes present in memory.
+
+    Returns
+    -------
+    num_words :
+        The number of words present in memory.
+    """
+    if memory_size % 32 == 0:
+        return memory_size // 32
+
+    return 1 + (memory_size // 32)
+
+
+def calculate_memory_cost(memory_size: int) -> int:
+    """
+    Calculate the gas cost for expanding the memory from 0 bytes to a
+    particular size in bytes.
+
+    Parameters
+    ----------
+    memory_size :
+        Number of bytes present in memory.
+
+    Returns
+    -------
+    gas_cost :
+        The cost of gas in expanding the memory from 0 to the preferred size.
+    """
+    memory_size_as_words = get_words(memory_size)
+
+    linear_gas_cost = GAS_MEMORY * memory_size_as_words
+    quadratic_gas_cost = (memory_size_as_words ** 2) // 512
+    return linear_gas_cost + quadratic_gas_cost
+
+
+def expand_memory(evm: Evm, memory_size: int) -> None:
+    """
+    Expand the memory from the current size to the given size.
+    Here memory size is defined as the number of bytes in memory.
+    This function also calculates and deducts the gas involved for the
+    memory expansion.
+
+    Parameters
+    ----------
+    evm :
+        The current EVM frame.
+    memory_size :
+        The required memory size to which the memory is to be expanded.
+    """
+    # The existing memory cost would have already been paid.
+    existing_memory_cost = calculate_memory_cost(len(evm.memory))
+    expanded_memory_cost = calculate_memory_cost(memory_size)
+    expansion_gas_cost = expanded_memory_cost - existing_memory_cost
+
+    evm.gas_left = subtract_gas(evm.gas_left, cast(U256, expansion_gas_cost))
+
+    bytes_to_add_to_memory = memory_size - len(evm.memory)
+    evm.memory += b"\x00" * bytes_to_add_to_memory

--- a/src/ethereum/utils.py
+++ b/src/ethereum/utils.py
@@ -19,12 +19,12 @@ def get_sign(value: int) -> int:
 
     Parameters
     ----------
-    value : `int`
+    value :
         The value whose sign is to be determined.
 
     Returns
     -------
-    sign : `int`
+    sign :
         The sign of the number (-1 or 0 or 1).
         The return value is based on math signum function.
     """
@@ -34,3 +34,23 @@ def get_sign(value: int) -> int:
         return 0
     else:
         return 1
+
+
+def get_ceil32(value: int) -> int:
+    """
+    Get the nearest multiple of 32.
+
+    If the value is already a perfect multiple of 32 then the resut is same
+    as the input.
+
+    Parameters
+    ----------
+    value :
+        The value for which we want to obtain the ceil value.
+
+    Returns
+    -------
+    ceil32 :
+        The ceil value which is the nearest multiple of 32.
+    """
+    return 32 * ((value + 31) // 32)

--- a/tests/frontier/vm/test_arithmetic_operations.py
+++ b/tests/frontier/vm/test_arithmetic_operations.py
@@ -48,7 +48,7 @@ def test_sub(test_file: str) -> None:
         "mul4.json",
         "mul5.json",
         "mul6.json",
-        # TODO: Uncomment mul7.json once MLOAD, MSTORE is implemented
+        # TODO: Uncomment mul7.json once RETURN is implemented
         # "mul7.json",
     ],
 )
@@ -59,7 +59,7 @@ def test_mul(test_file: str) -> None:
 @pytest.mark.parametrize(
     "test_file",
     [
-        # TODO: Uncomment div1.json file once MSTORE is implemented
+        # TODO: Uncomment div1.json file once RETURN is implemented
         # "div1.json",
         "divBoostBug.json",
         "divByNonZero0.json",
@@ -93,8 +93,7 @@ def test_div(test_file: str) -> None:
         "sdiv_i256min.json",
         "sdiv_i256min2.json",
         "sdiv_i256min3.json",
-        # TODO: Run sdiv_dejavu.json once DUP series has been implemented
-        # "sdiv_dejavu.json",
+        "sdiv_dejavu.json",
     ],
 )
 def test_sdiv(test_file: str) -> None:
@@ -170,7 +169,7 @@ def test_addmod(test_file: str) -> None:
         "mulmod2.json",
         # TODO: Test files 'mulmod2_1.json', 'mulmod3_0.json' after implementing EQ
         # TODO: Test file 'mulmod2_0.json' after implementing SMOD
-        # TODO: Test file 'mulmod4.json' after implementing MSTORE8
+        # TODO: Test file 'mulmod4.json' after implementing RETURN
         # "mulmod2_0.json",
         # "mulmod2_1.json",
         "mulmod3.json",

--- a/tests/frontier/vm/test_memory_operations.py
+++ b/tests/frontier/vm/test_memory_operations.py
@@ -1,0 +1,94 @@
+from functools import partial
+
+import pytest
+
+from ethereum.frontier.vm.error import OutOfGasError
+from tests.frontier.vm.vm_test_helpers import run_test
+
+run_memory_vm_test = partial(
+    run_test,
+    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+)
+
+
+# TODO: Investigate what is erroneous about these test cases.
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "mloadError0.json",
+        "mloadError1.json",
+    ],
+)
+def test_mload(test_file: str) -> None:
+    run_memory_vm_test(test_file)
+
+
+# TODO: Investigate why mloadMemExp.json is not suffixed with Error
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "mloadMemExp.json",
+        "mloadOutOfGasError2.json",
+    ],
+)
+def test_mload_out_of_gas_error(test_file: str) -> None:
+    with pytest.raises(OutOfGasError):
+        run_memory_vm_test(test_file)
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "mstore0.json",
+        "mstore1.json",
+        # TODO: Investigate why below test is suffixed with Error
+        "mstoreWordToBigError.json",
+    ],
+)
+def test_mstore(test_file: str) -> None:
+    run_memory_vm_test(test_file)
+
+
+def test_mstore_out_of_gas_error() -> None:
+    with pytest.raises(OutOfGasError):
+        run_memory_vm_test("mstoreMemExp.json")
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "mstore8_0.json",
+        "mstore8_1.json",
+        # TODO: Investigate why below test is suffixed with Error
+        "mstore8WordToBigError.json",
+    ],
+)
+def test_mstore8(test_file: str) -> None:
+    run_memory_vm_test(test_file)
+
+
+def test_mstore8_out_of_gas_error() -> None:
+    with pytest.raises(OutOfGasError):
+        run_memory_vm_test("mstore8MemExp.json")
+
+
+def test_mstore_mload() -> None:
+    run_memory_vm_test("mstore_mload0.json")
+
+
+# TODO: Run below test once "RETURN" opcode has been implemented.
+# def test_generic_memory_operations() -> None:
+#     run_memory_vm_test("memory1.json")
+
+
+@pytest.mark.parametrize(
+    "test_file",
+    [
+        "msize0.json",
+        "msize1.json",
+        "msize2.json",
+        "msize3.json",
+    ],
+)
+def test_msize(test_file: str) -> None:
+    run_memory_vm_test(test_file)

--- a/tests/frontier/vm/test_stack_operations.py
+++ b/tests/frontier/vm/test_stack_operations.py
@@ -2,6 +2,7 @@ from functools import partial
 
 import pytest
 
+from ethereum.frontier.vm.error import StackUnderflowError
 from tests.frontier.vm.vm_test_helpers import run_test
 
 run_push_vm_test = partial(
@@ -10,13 +11,18 @@ run_push_vm_test = partial(
 )
 run_dup_vm_test = run_swap_vm_test = run_push_vm_test
 
+run_pop_vm_test = partial(
+    run_test,
+    "tests/fixtures/LegacyTests/Constantinople/VMTests/vmIOandFlowOperations",
+)
+
 
 def test_push_successfully() -> None:
     for i in range(1, 34):
         run_push_vm_test(f"push{i}.json")
 
     run_push_vm_test("push32Undefined2.json")
-    # TODO: Run below test once suicide opcode has been implemented
+    # TODO: Run below test once SUICIDE opcode has been implemented
     # "push32AndSuicide.json"
 
 
@@ -55,3 +61,12 @@ def test_swap() -> None:
 def test_swap_error() -> None:
     with pytest.raises(AssertionError):
         run_swap_vm_test("swap2error.json")
+
+
+def test_pop_succeeds() -> None:
+    run_pop_vm_test("pop0.json")
+
+
+def test_pop_fails_with_underflow() -> None:
+    with pytest.raises(StackUnderflowError):
+        run_pop_vm_test("pop1.json")

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -69,6 +69,7 @@ vm
 num
 utils
 prepend
+ceil32
 
 sha3
 


### PR DESCRIPTION
### What was wrong?
The following opcodes weren't implemented.
- [x] MLOAD
- [x] MSTORE
- [x] MSTORE8
- [x] MSIZE
- [x] POP

### How was it fixed?
Following frontier yellow paper

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://imagesvc.meredithcorp.io/v3/mm/image?q=85&c=sc&poi=face&w=2000&h=1000&url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F24%2F2020%2F09%2F24%2FGettyImages-184129038-2000.jpg)
