### PR TITLE
london: update geth mainnet version

### DIFF
--- a/network-upgrades/mainnet-upgrades/london.md
+++ b/network-upgrades/mainnet-upgrades/london.md
@@ -52,7 +52,7 @@ Code merged into Participating Clients
    - [x]  Erigon [v2021.06.04-alpha](https://github.com/ledgerwatch/erigon/releases/tag/v2021.06.04)
    - [x]  EthereumJS [v5.4.1](https://github.com/ethereumjs/ethereumjs-monorepo/releases/tag/%40ethereumjs%2Fvm%405.4.1)
  - [x]  Mainnet 
-   - [x]  Geth [v1.10.5](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.5)
+   - [x]  Geth [v1.10.6](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.6)
    - [x]  Besu [v21.7.1](https://github.com/hyperledger/besu/releases/tag/21.7.1)
    - [x]  Nethermind [v1.10.77](https://github.com/NethermindEth/nethermind/releases/tag/1.10.77)
    - [x]  OpenEthereum [v3.3.0-rc.4](https://github.com/openethereum/openethereum/releases/tag/v3.3.0-rc.4)


### PR DESCRIPTION
### What was wrong?

During testing of the London hardfork on Ropsten, a consensus failure occurred in block 10679538, leading to a network split between OpenEthereum/Besu and Geth/Nethermind. The block contained a transaction from an account with enough funds to cover the effective fee, but too little funds for the transaction's maximum gas price. EIP-1559 mandates that such transactions should be rejected. Geth's implementation of EIP-1559 did not perform the check correctly and accepted the transaction.

For more information see [PR #23244](https://github.com/ethereum/go-ethereum/pull/23244) and the [post-mortem writeup](https://notes.ethereum.org/@timbeiko/ropsten-postmortem).

### How was it fixed?

[Geth v1.10.6](https://github.com/ethereum/go-ethereum/releases/tag/v1.10.6) is a hotfix release. This resolves a consensus failure on the Ropsten testnet.

Users of Geth on the Ethereum mainnet must upgrade to this release before the London hard-fork activates to remain in consensus. 

#### Cute Animal Picture

![Cute Cat Love](https://user-images.githubusercontent.com/11676828/126731710-1d1c4ced-a29c-476c-b478-8cdffae0c5e1.jpg)


