### PR TITLE
Fee history oldest block should only return an integer and not a block tag

### DIFF
--- a/json-rpc/spec.json
+++ b/json-rpc/spec.json
@@ -247,7 +247,7 @@
 						"oldestBlock": {
 							"title": "oldestBlock",
 							"description": "Lowest number block of the returned range.",
-							"$ref": "#/components/schemas/BlockNumber"
+							"$ref": "#/components/schemas/Integer"
 						},
 						"baseFeePerGas": {
 							"title": "baseFeePerGasArray",


### PR DESCRIPTION
### What was wrong?

The `oldestBlock` return value for `eth_history` should only return a integer block number, not a block tag like `latest`. 

### How was it fixed?

Use the integer type instead.

#### Cute Animal Picture

![](https://en.bcdn.biz/Images/2016/11/15/776342f0-86f5-4522-84c9-a02d6b11c766.jpg)
