### PR TITLE
Run commented test cases as the required opcodes have been implemented

### DIFF
--- a/src/ethereum/frontier/vm/runtime.py
+++ b/src/ethereum/frontier/vm/runtime.py
@@ -50,6 +50,7 @@ def get_valid_jump_destinations(code: bytes) -> Set[Uint]:
             # Skip invalid opcodes, as they don't affect the jumpdest
             # analysis. Nevertheless, such invalid opcodes would be caught
             # and raised when the interpreter runs.
+            pc += 1
             continue
 
         if current_opcode == Ops.JUMPDEST:

--- a/tests/frontier/vm/test_arithmetic_operations.py
+++ b/tests/frontier/vm/test_arithmetic_operations.py
@@ -48,7 +48,7 @@ def test_sub(test_file: str) -> None:
         "mul4.json",
         "mul5.json",
         "mul6.json",
-        # TODO: Uncomment mul7.json once MLOAD, MSTORE is implemented
+        # TODO: Uncomment mul7.json once RETURN is implemented
         # "mul7.json",
     ],
 )
@@ -59,7 +59,7 @@ def test_mul(test_file: str) -> None:
 @pytest.mark.parametrize(
     "test_file",
     [
-        # TODO: Uncomment div1.json file once MSTORE is implemented
+        # TODO: Uncomment div1.json file once RETURN is implemented
         # "div1.json",
         "divBoostBug.json",
         "divByNonZero0.json",
@@ -93,8 +93,7 @@ def test_div(test_file: str) -> None:
         "sdiv_i256min.json",
         "sdiv_i256min2.json",
         "sdiv_i256min3.json",
-        # TODO: Run sdiv_dejavu.json once DUP series has been implemented
-        # "sdiv_dejavu.json",
+        "sdiv_dejavu.json",
     ],
 )
 def test_sdiv(test_file: str) -> None:
@@ -146,12 +145,10 @@ def test_smod(test_file: str) -> None:
         "addmod1_overflow4.json",
         "addmod1_overflowDiff.json",
         "addmod2.json",
-        # TODO: Test files 'addmod2_1.json', 'addmod3_0.json' after implementing EQ
-        # TODO: Test file 'addmod2_0.json' after implementing EQ
-        # "addmod2_0.json",
-        # "addmod2_1.json",
+        "addmod2_0.json",
+        "addmod2_1.json",
         "addmod3.json",
-        # "addmod3_0.json",
+        "addmod3_0.json",
     ],
 )
 def test_addmod(test_file: str) -> None:
@@ -168,13 +165,11 @@ def test_addmod(test_file: str) -> None:
         "mulmod1_overflow3.json",
         "mulmod1_overflow4.json",
         "mulmod2.json",
-        # TODO: Test files 'mulmod2_1.json', 'mulmod3_0.json' after implementing EQ
-        # TODO: Test file 'mulmod2_0.json' after implementing SMOD
-        # TODO: Test file 'mulmod4.json' after implementing MSTORE8
-        # "mulmod2_0.json",
-        # "mulmod2_1.json",
+        "mulmod2_0.json",
+        "mulmod2_1.json",
         "mulmod3.json",
-        # "mulmod3_0.json",
+        "mulmod3_0.json",
+        # TODO: Test file 'mulmod4.json' after implementing RETURN opcode
         # "mulmod4.json",
     ],
 )
@@ -194,9 +189,8 @@ def test_mulmod(test_file: str) -> None:
         "exp6.json",
         "exp7.json",
         "exp8.json",
-        # TODO: Run expXY.json, expXY_success.json when CALLDATALOAD is implemented
-        # "expXY.json",
-        # "expXY_success.json",
+        "expXY.json",
+        "expXY_success.json",
     ],
 )
 def test_exp(test_file: str) -> None:
@@ -230,8 +224,7 @@ def test_exp_power_256() -> None:
         "signextend_BitIsNotSetInHigherByte.json",
         "signextend_bitIsSet.json",
         "signextend_BitIsSetInHigherByte.json",
-        # TODO: Run the below commented test after implementing JUMP opcode
-        # "signextend_Overflow_dj42.json",
+        "signextend_Overflow_dj42.json",
         "signextendInvalidByteNumber.json",
     ],
 )

--- a/tests/frontier/vm/test_environmental_operations.py
+++ b/tests/frontier/vm/test_environmental_operations.py
@@ -70,8 +70,7 @@ def test_calldatasize(test_file: str) -> None:
         "calldatacopyZeroMemExpansion.json",
         "calldatacopy_DataIndexTooHigh.json",
         "calldatacopy_DataIndexTooHigh2.json",
-        # TODO: Run below test case once the JUMP opcode is implemented
-        # "calldatacopy_sec.json",
+        "calldatacopy_sec.json",
         # TODO: Run the above test cases which end with `_return.json` once
         # RETURN opcode is implemented.
     ],

--- a/tests/frontier/vm/test_logging_operations.py
+++ b/tests/frontier/vm/test_logging_operations.py
@@ -102,8 +102,7 @@ def test_log2_fail_required_gas_overflows(test_file: str) -> None:
         "log3_nonEmptyMem.json",
         "log3_nonEmptyMem_logMemSize1.json",
         "log3_nonEmptyMem_logMemSize1_logMemStart31.json",
-        # TODO: Run below test case once `PC` opcode has been implemented
-        # "log3_PC.json",
+        "log3_PC.json",
     ],
 )
 def test_log3(test_file: str) -> None:
@@ -132,8 +131,7 @@ def test_log3_fail_required_gas_overflows(test_file: str) -> None:
         "log4_nonEmptyMem.json",
         "log4_nonEmptyMem_logMemSize1.json",
         "log4_nonEmptyMem_logMemSize1_logMemStart31.json",
-        # TODO: Run below test case once `PC` opcode has been implemented
-        # "log4_PC.json",
+        "log4_PC.json",
     ],
 )
 def test_log4(test_file: str) -> None:

--- a/tests/frontier/vm/test_storage_operations.py
+++ b/tests/frontier/vm/test_storage_operations.py
@@ -17,6 +17,8 @@ run_storage_vm_test = partial(
         "sstore_load_0.json",
         "sstore_load_1.json",
         "sstore_load_2.json",
+        # TODO: Run below test once RETURN opcode has been implemented.
+        # "kv1.json",
     ],
 )
 def test_sstore_and_sload(test_file: str) -> None:


### PR DESCRIPTION
### What was wrong?
Few tests were previously commented out as all the opcodes haven't been implemented. Most of those commented tests are now running. This also fixes the infinite loop in `get_valid_jump_destinations` when there is no valid opcode.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1560114928-40f1f1eb26a0?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8Y3V0ZSUyMGFuaW1hbHxlbnwwfHwwfHw%3D&w=1000&q=80)
