### PR TITLE
Add EthGasStation to ecosystem readiness

### DIFF
--- a/network-upgrades/ecosystem-readiness.md
+++ b/network-upgrades/ecosystem-readiness.md
@@ -95,6 +95,7 @@ Many of these projects may not update until much closer to the designated London
 | [Ethernodes][ethernodes-link] | Node Explorer | Eth 1.0 Clients |  | ? |  |✅ 
 | [TREZOR][trezor-link] | Hardware Wallet |  | [URL][trezor-work] | 1559 |  |🛠️ 
 | [WallETH][walleth-link] | Wallet | KEthereum | [URL][walleth-work] | 1559 |  |🛠️  
+| [ETH Gas Station][ethgasstation-link] | Metrics for the gas market | Web3.js | [URL][walleth-work] | 1559 |  |🛠️  
 
 [AWS-link]: https://aws.amazon.com/managed-blockchain/
 [blocknative-link]: https://github.com/blocknative
@@ -108,4 +109,5 @@ Many of these projects may not update until much closer to the designated London
 [trezor-work]: https://github.com/trezor/trezor-firmware/issues/1604
 [walleth-link]: https://walleth.org
 [walleth-work]: https://github.com/walleth/walleth/issues/523
+[ethgasstation-link]: https://ethgasstation.info
 


### PR DESCRIPTION
### What was wrong?
Gas metrics dashboards are obviously impacted by the change.
https://ethgasstation.info is one of them.

Related to Issue #

### How was it fixed?
Adding https://ethgasstation.info to the ecosystem readiness, Infrastructure section.


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://p4.wallpaperbetter.com/wallpaper/782/136/908/antarctic-penguins-wallpaper-preview.jpg)
