### PR TITLE
Add Ledger to the ecosystem readiness

### DIFF
--- a/network-upgrades/ecosystem-readiness.md
+++ b/network-upgrades/ecosystem-readiness.md
@@ -95,6 +95,7 @@ Many of these projects may not update until much closer to the designated London
 | [Ethernodes][ethernodes-link] |Node Explorer | Eth 1.0 Clients |  | ? |✅ 
 | [TREZOR][trezor-link] |Hardware Wallet |  | [URL][trezor-work] | 1559 |🛠️ 
 | [WallETH][walleth-link] |Wallet | KEthereum | [URL][walleth-work] | 1559 |🛠️  
+| [Ledger][ledger-link] |Hardware Wallet | Ethers | | 1559 |🛠️  
 
 [AWS-link]: https://aws.amazon.com/managed-blockchain/
 [blocknative-link]: https://github.com/blocknative
@@ -108,4 +109,4 @@ Many of these projects may not update until much closer to the designated London
 [trezor-work]: https://github.com/trezor/trezor-firmware/issues/1604
 [walleth-link]: https://walleth.org
 [walleth-work]: https://github.com/walleth/walleth/issues/523
-
+[ledger-link]: https://ledger.com


### PR DESCRIPTION
### What was wrong?

Ledger is missing from the ecosystem readiness list. We're currently working to support EIP-1559.

### How was it fixed?

Adding [Ledger](https://www.ledger.com/) to the ecosystem readiness list.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://besthqwallpapers.com/Uploads/27-9-2020/142121/thumb2-koala-cute-animals-wildlife-little-koala-wild-animals.jpg)
