### PR TITLE
Add a proper state interface

### DIFF
--- a/src/ethereum/frontier/eth_types.py
+++ b/src/ethereum/frontier/eth_types.py
@@ -13,7 +13,7 @@ Types re-used throughout the specification, which are specific to Ethereum.
 """
 
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from ..base_types import (
     U256,
@@ -23,7 +23,6 @@ from ..base_types import (
     Bytes32,
     Bytes256,
     Uint,
-    modify,
     slotted_freezable,
 )
 from ..crypto import Hash32
@@ -67,14 +66,12 @@ class Account:
     nonce: Uint
     balance: U256
     code: bytes
-    storage: Storage
 
 
 EMPTY_ACCOUNT = Account(
     nonce=Uint(0),
     balance=U256(0),
     code=bytearray(),
-    storage={},
 )
 
 
@@ -137,36 +134,3 @@ class Receipt:
     cumulative_gas_used: Uint
     bloom: Bloom
     logs: Tuple[Log, ...]
-
-
-State = Dict[Address, Account]
-
-
-def modify_state(
-    state: State, address: Address, f: Callable[[Account], None]
-) -> None:
-    """
-    Modify an `Account` in the `State`.
-    """
-    state[address] = modify(state[address], f)
-
-
-def move_ether(
-    state: State,
-    sender_address: Address,
-    recipient_address: Address,
-    amount: U256,
-) -> None:
-    """
-    Move funds between accounts.
-    """
-
-    def reduce_sender_balance(sender: Account) -> None:
-        assert sender.balance >= amount
-        sender.balance -= amount
-
-    def increase_recipient_balance(recipient: Account) -> None:
-        recipient.balance += amount
-
-    modify_state(state, sender_address, reduce_sender_balance)
-    modify_state(state, recipient_address, increase_recipient_balance)

--- a/src/ethereum/frontier/rlp.py
+++ b/src/ethereum/frontier/rlp.py
@@ -69,8 +69,6 @@ def encode(raw_data: RLP) -> Bytes:
         return encode_block(raw_data)
     elif isinstance(raw_data, Header):
         return encode_header(raw_data)
-    elif isinstance(raw_data, Account):
-        return encode_account(raw_data)
     elif isinstance(raw_data, Transaction):
         return encode_transaction(raw_data)
     elif isinstance(raw_data, Receipt):
@@ -102,12 +100,12 @@ def encode_bytes(raw_bytes: Bytes) -> Bytes:
     if len_raw_data == 1 and raw_bytes[0] < 0x80:
         return raw_bytes
     elif len_raw_data < 0x38:
-        return bytearray([0x80 + len_raw_data]) + raw_bytes
+        return bytes([0x80 + len_raw_data]) + raw_bytes
     else:
         # length of raw data represented as big endian bytes
         len_raw_data_as_be = len_raw_data.to_be_bytes()
         return (
-            bytearray([0xB7 + len(len_raw_data_as_be)])
+            bytes([0xB7 + len(len_raw_data_as_be)])
             + len_raw_data_as_be
             + raw_bytes
         )
@@ -424,21 +422,18 @@ def encode_header(raw_header_data: Header) -> Bytes:
     )
 
 
-def encode_account(raw_account_data: Account) -> Bytes:
+def encode_account(raw_account_data: Account, storage_root: Bytes) -> Bytes:
     """
-    Encode `Account` dataclass
-    """
-    # TODO: This function should be split into 2 functions. One to
-    # patricialize the storage root and hashing code. Another for rlp
-    # encoding the previously obtained data.
-    # Imported here to prevent circular dependency
-    from .trie import map_keys, root
+    Encode `Account` dataclass.
 
+    Storage is not stored in the `Account` dataclass, so `Accounts` cannot be
+    enocoded with providing a storage root.
+    """
     return encode(
         (
             raw_account_data.nonce,
             raw_account_data.balance,
-            root(map_keys(raw_account_data.storage)),
+            storage_root,
             keccak256(raw_account_data.code),
         )
     )

--- a/src/ethereum/frontier/state.py
+++ b/src/ethereum/frontier/state.py
@@ -1,0 +1,221 @@
+"""
+State
+^^^^^
+
+.. contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+The state contains all information that is preserved between transactions.
+
+It consists of a main account trie and storage tries for each contract.
+"""
+from dataclasses import dataclass, field
+from typing import Callable, Dict
+
+from ethereum.base_types import U256, Bytes, modify
+
+from .eth_types import EMPTY_ACCOUNT, Account, Address, Root
+from .trie import EMPTY_TRIE_ROOT, Trie, root, trie_get, trie_set
+
+
+@dataclass
+class State:
+    """
+    Contains all information that is preserved between transactions.
+    """
+
+    _main_trie: Trie[Account] = field(
+        default_factory=lambda: Trie(secured=True, default=EMPTY_ACCOUNT)
+    )
+    _storage_tries: Dict[Address, Trie[U256]] = field(default_factory=dict)
+
+
+def get_account(state: State, address: Address) -> Account:
+    """
+    Get the `Account` object at an address. Returns `EMPTY_ACCOUNT` if there
+    is no account at the address.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address to lookup.
+
+    Returns
+    -------
+    account : `Account`
+        Account at address.
+    """
+    account = trie_get(state._main_trie, address)
+    assert isinstance(account, Account)
+    return account
+
+
+def set_account(state: State, address: Address, account: Account) -> None:
+    """
+    Set the `Account` object at an address. Setting to `EMPTY_ACCOUNT` deletes
+    the account (but not its storage, see `destroy_account()`).
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address to set.
+    account : `Account`
+        Account to set at address.
+    """
+    trie_set(state._main_trie, address, account)
+
+
+def destroy_account(state: State, address: Address) -> None:
+    """
+    Completely remove the account at `address` and all of its storage.
+
+    This function is made available exclusively for the `SELFDESTRUCT`
+    opcode. It is expected that `SELFDESTRUCT` will be disabled in a future
+    hardfork and this function will be removed.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of account to destroy.
+    """
+    del state._storage_tries[address]
+    set_account(state, address, EMPTY_ACCOUNT)
+
+
+def get_storage(state: State, address: Address, key: Bytes) -> U256:
+    """
+    Get a value at a storage key on an account. Returns `U256(0)` if the
+    storage key has not been set previously.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of the account.
+    key : `Bytes`
+        Key to lookup.
+
+    Returns
+    -------
+    value : `U256`
+        Value at the key.
+    """
+    trie = state._storage_tries.get(address)
+    if trie is None:
+        return U256(0)
+
+    value = trie_get(trie, key)
+
+    assert isinstance(value, U256)
+    return value
+
+
+def set_storage(
+    state: State, address: Address, key: Bytes, value: U256
+) -> None:
+    """
+    Set a value at a storage key on an account. Setting to `U256(0)` deletes
+    the key.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of the account.
+    key : `Bytes`
+        Key to set.
+    value : `U256`
+        Value to set at the key.
+    """
+    trie = state._storage_tries.get(address)
+    if trie is None:
+        trie = Trie(secured=True, default=U256(0))
+        state._storage_tries[address] = trie
+    trie_set(trie, key, value)
+    if trie._data == {}:
+        del state._storage_tries[address]
+
+
+def storage_root(state: State, address: Address) -> Bytes:
+    """
+    Calculate the storage root of an account.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+    address : `Address`
+        Address of the account.
+
+    Returns
+    -------
+    root : `Bytes`
+        Storage root of the account.
+    """
+    if address in state._storage_tries:
+        return root(state._storage_tries[address])
+    else:
+        return EMPTY_TRIE_ROOT
+
+
+def state_root(state: State) -> Bytes:
+    """
+    Calculate the state root.
+
+    Parameters
+    ----------
+    state: `State`
+        The state
+
+    Returns
+    -------
+    root : `Bytes`
+        The state root.
+    """
+
+    def get_storage_root(address: Address) -> Root:
+        return storage_root(state, address)
+
+    return root(state._main_trie, get_storage_root=get_storage_root)
+
+
+def modify_state(
+    state: State, address: Address, f: Callable[[Account], None]
+) -> None:
+    """
+    Modify an `Account` in the `State`.
+    """
+    set_account(state, address, modify(get_account(state, address), f))
+
+
+def move_ether(
+    state: State,
+    sender_address: Address,
+    recipient_address: Address,
+    amount: U256,
+) -> None:
+    """
+    Move funds between accounts.
+    """
+
+    def reduce_sender_balance(sender: Account) -> None:
+        assert sender.balance >= amount
+        sender.balance -= amount
+
+    def increase_recipient_balance(recipient: Account) -> None:
+        recipient.balance += amount
+
+    modify_state(state, sender_address, reduce_sender_balance)
+    modify_state(state, recipient_address, increase_recipient_balance)

--- a/src/ethereum/frontier/vm/__init__.py
+++ b/src/ethereum/frontier/vm/__init__.py
@@ -19,7 +19,8 @@ from typing import List, Set, Tuple
 from ethereum.base_types import U256, Uint
 from ethereum.crypto import Hash32
 
-from ..eth_types import Address, Log, State
+from ..eth_types import Address, Log
+from ..state import State
 
 __all__ = ("Environment", "Evm")
 

--- a/src/ethereum/frontier/vm/interpreter.py
+++ b/src/ethereum/frontier/vm/interpreter.py
@@ -17,7 +17,8 @@ from typing import Tuple
 from ethereum.base_types import U256, Uint
 from ethereum.frontier.vm.error import InvalidOpcode
 
-from ..eth_types import Address, Log, move_ether
+from ..eth_types import Address, Log
+from ..state import get_account, move_ether
 from . import Environment, Evm
 from .instructions import Ops, op_implementation
 from .runtime import get_valid_jump_destinations
@@ -67,7 +68,7 @@ def process_call(
         after execution, and logs is the list of `eth1spec.eth_types.Log`
         generated during execution.
     """
-    code = env.state[target].code
+    code = get_account(env.state, target).code
     valid_jump_destinations = get_valid_jump_destinations(code)
 
     evm = Evm(

--- a/tests/frontier/test_trie.py
+++ b/tests/frontier/test_trie.py
@@ -1,8 +1,8 @@
 import json
-from typing import Any
+from typing import Any, cast
 
 from ethereum.frontier.eth_types import Bytes
-from ethereum.frontier.trie import map_keys, root
+from ethereum.frontier.trie import Trie, root, trie_set
 from ethereum.utils.hexadecimal import (
     has_hex_prefix,
     hex_to_bytes,
@@ -23,11 +23,10 @@ def test_trie_secure_hex() -> None:
     tests = load_tests("hex_encoded_securetrie_test.json")
 
     for (name, test) in tests.items():
-        normalized = {}
+        st = Trie(secured=True, default=b"")
         for (k, v) in test.get("in").items():
-            normalized[to_bytes(k)] = to_bytes(v)
-
-        result = root(map_keys(normalized))
+            trie_set(st, to_bytes(k), to_bytes(v))
+        result = root(st)
         expected = remove_hex_prefix(test.get("root"))
         assert result.hex() == expected, f"test {name} failed"
 
@@ -36,11 +35,10 @@ def test_trie_secure() -> None:
     tests = load_tests("trietest_secureTrie.json")
 
     for (name, test) in tests.items():
-        normalized = {}
+        st = Trie(secured=True, default=b"")
         for t in test.get("in"):
-            normalized[to_bytes(t[0])] = to_bytes(t[1])
-
-        result = root(map_keys(normalized))
+            trie_set(st, to_bytes(t[0]), to_bytes(t[1]))
+        result = root(st)
         expected = remove_hex_prefix(test.get("root"))
         assert result.hex() == expected, f"test {name} failed"
 
@@ -49,11 +47,10 @@ def test_trie_secure_any_order() -> None:
     tests = load_tests("trieanyorder_secureTrie.json")
 
     for (name, test) in tests.items():
-        normalized = {}
+        st = Trie(secured=True, default=b"")
         for (k, v) in test.get("in").items():
-            normalized[to_bytes(k)] = to_bytes(v)
-
-        result = root(map_keys(normalized))
+            trie_set(st, to_bytes(k), to_bytes(v))
+        result = root(st)
         expected = remove_hex_prefix(test.get("root"))
         assert result.hex() == expected, f"test {name} failed"
 
@@ -62,11 +59,10 @@ def test_trie() -> None:
     tests = load_tests("trietest.json")
 
     for (name, test) in tests.items():
-        normalized = {}
+        st = Trie(secured=False, default=b"")
         for t in test.get("in"):
-            normalized[to_bytes(t[0])] = to_bytes(t[1])
-
-        result = root(map_keys(normalized, secured=False))
+            trie_set(st, to_bytes(t[0]), to_bytes(t[1]))
+        result = root(st)
         expected = remove_hex_prefix(test.get("root"))
         assert result.hex() == expected, f"test {name} failed"
 
@@ -75,11 +71,10 @@ def test_trie_any_order() -> None:
     tests = load_tests("trieanyorder.json")
 
     for (name, test) in tests.items():
-        normalized = {}
+        st = Trie(secured=False, default=b"")
         for (k, v) in test.get("in").items():
-            normalized[to_bytes(k)] = to_bytes(v)
-
-        result = root(map_keys(normalized, secured=False))
+            trie_set(st, to_bytes(k), to_bytes(v))
+        result = root(st)
         expected = remove_hex_prefix(test.get("root"))
         assert result.hex() == expected, f"test {name} failed"
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -235,3 +235,10 @@ selfdestruct
 ceil32
 rjust
 ljust
+
+subnode
+subnodes
+unencoded
+setitem
+getitem
+delitem


### PR DESCRIPTION
![Put a link to a cute animal picture inside the parenthesis-->](https://www.zoochat.com/community/media/rusty-spotted-cat-april-2015.290055/full?d=1429086471)

This pull request adds a proper state interface in the form of `State` and `Trie` types. Both of these types are designed so they can be easily replaced by faster implementations if needed. The trie code has also been refactored to be clearer.

Initializing and deletion of accounts happens automatically. Since in the Ethereum state datamodel values such as `EMPTY_ACCOUNT` and `U256(0)` are represented by their absence, an entry can be deleted by setting it to one of these values.

`SELFDESTRUCT` will require special handling, which is not currently implemented.