### PR TITLE
Move modules depending on frontier types into frontier hardfork

### DIFF
--- a/src/ethereum/frontier/genesis.py
+++ b/src/ethereum/frontier/genesis.py
@@ -18,15 +18,15 @@ from dataclasses import dataclass
 from typing import Dict, cast
 
 from ethereum.base_types import U256, Bytes, Bytes8, Uint, slotted_freezable
-from ethereum.frontier.eth_types import Address
-
-from .utils.hexadecimal import (
-    hex_to_address,
+from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     hex_to_bytes8,
     hex_to_u256,
     hex_to_uint,
 )
+
+from .eth_types import Address
+from .utils.hexadecimal import hex_to_address
 
 
 @slotted_freezable

--- a/src/ethereum/frontier/utils/hexadecimal.py
+++ b/src/ethereum/frontier/utils/hexadecimal.py
@@ -1,0 +1,68 @@
+"""
+Utility Functions For Hexadecimal Strings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+..contents:: Table of Contents
+    :backlinks: none
+    :local:
+
+Introduction
+------------
+
+Hexadecimal utility functions used in this specification, specific to Frontier
+types.
+"""
+from ethereum.utils.hexadecimal import remove_hex_prefix
+
+from ..eth_types import Address, Bloom, Root
+
+
+def hex_to_root(hex_string: str) -> Root:
+    """
+    Convert hex string to trie root.
+
+    Parameters
+    ----------
+    hex_string :
+        The hexadecimal string to be converted to trie root.
+
+    Returns
+    -------
+    root : `Root`
+        Trie root obtained from the given hexadecimal string.
+    """
+    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
+
+
+def hex_to_bloom(hex_string: str) -> Bloom:
+    """
+    Convert hex string to bloom.
+
+    Parameters
+    ----------
+    hex_string :
+        The hexadecimal string to be converted to bloom.
+
+    Returns
+    -------
+    bloom : `Bloom`
+        Bloom obtained from the given hexadecimal string.
+    """
+    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
+
+
+def hex_to_address(hex_string: str) -> Address:
+    """
+    Convert hex string to Address (20 bytes).
+
+    Parameters
+    ----------
+    hex_string :
+        The hexadecimal string to be converted to Address.
+
+    Returns
+    -------
+    address : `Address`
+        The address obtained from the given hexadecimal string.
+    """
+    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))

--- a/src/ethereum/frontier/utils/json.py
+++ b/src/ethereum/frontier/utils/json.py
@@ -14,14 +14,16 @@ Json specific utilities used in this frontier version of specification.
 from typing import Any, Dict, Tuple
 
 from ethereum.frontier.eth_types import Block, Header, Transaction
-from ethereum.utils.hexadecimal import (
+from ethereum.frontier.utils.hexadecimal import (
     hex_to_address,
     hex_to_bloom,
+    hex_to_root,
+)
+from ethereum.utils.hexadecimal import (
     hex_to_bytes,
     hex_to_bytes8,
     hex_to_bytes32,
     hex_to_hash,
-    hex_to_root,
     hex_to_u256,
     hex_to_uint,
 )

--- a/src/ethereum/utils/hexadecimal.py
+++ b/src/ethereum/utils/hexadecimal.py
@@ -13,7 +13,6 @@ Hexadecimal strings specific utility functions used in this specification.
 """
 from ethereum.base_types import U256, Bytes, Bytes8, Bytes32, Uint
 from ethereum.crypto import Hash32
-from ethereum.frontier.eth_types import Address, Bloom, Root
 
 
 def has_hex_prefix(hex_string: str) -> bool:
@@ -120,57 +119,6 @@ def hex_to_hash(hex_string: str) -> Hash32:
         32-byte stream obtained from the given hexadecimal string.
     """
     return Hash32(bytes.fromhex(remove_hex_prefix(hex_string)))
-
-
-def hex_to_root(hex_string: str) -> Root:
-    """
-    Convert hex string to trie root.
-
-    Parameters
-    ----------
-    hex_string :
-        The hexadecimal string to be converted to trie root.
-
-    Returns
-    -------
-    root : `Root`
-        Trie root obtained from the given hexadecimal string.
-    """
-    return Root(bytes.fromhex(remove_hex_prefix(hex_string)))
-
-
-def hex_to_bloom(hex_string: str) -> Bloom:
-    """
-    Convert hex string to bloom.
-
-    Parameters
-    ----------
-    hex_string :
-        The hexadecimal string to be converted to bloom.
-
-    Returns
-    -------
-    bloom : `Bloom`
-        Bloom obtained from the given hexadecimal string.
-    """
-    return Bloom(bytes.fromhex(remove_hex_prefix(hex_string)))
-
-
-def hex_to_address(hex_string: str) -> Address:
-    """
-    Convert hex string to Address (20 bytes).
-
-    Parameters
-    ----------
-    hex_string :
-        The hexadecimal string to be converted to Address.
-
-    Returns
-    -------
-    address : `Address`
-        The address obtained from the given hexadecimal string.
-    """
-    return Address(bytes.fromhex(remove_hex_prefix(hex_string).rjust(40, "0")))
 
 
 def hex_to_uint(hex_string: str) -> Uint:

--- a/tests/frontier/blockchain_st_test_helpers.py
+++ b/tests/frontier/blockchain_st_test_helpers.py
@@ -9,13 +9,12 @@ from ethereum.frontier.eth_types import Account, Block, Header, Transaction
 from ethereum.frontier.rlp import rlp_hash
 from ethereum.frontier.spec import BlockChain, state_transition
 from ethereum.frontier.state import State, set_account, set_storage
+from ethereum.frontier.utils.hexadecimal import hex_to_address, hex_to_root
 from ethereum.utils.hexadecimal import (
-    hex_to_address,
     hex_to_bytes,
     hex_to_bytes8,
     hex_to_bytes32,
     hex_to_hash,
-    hex_to_root,
     hex_to_u256,
     hex_to_uint,
 )

--- a/tests/frontier/test_genesis.py
+++ b/tests/frontier/test_genesis.py
@@ -5,7 +5,7 @@ import pytest
 
 from ethereum.base_types import U256, Bytes
 from ethereum.frontier import rlp
-from ethereum.genesis import genesis_configuration
+from ethereum.frontier.genesis import genesis_configuration
 
 MAINNET_GENESIS_CONFIGURATION = genesis_configuration("mainnet.json")
 
@@ -14,7 +14,7 @@ MAINNET_GENESIS_CONFIGURATION = genesis_configuration("mainnet.json")
 def mainnet_alloc_rlp_encoding() -> bytes:
     rlp_encoding_hex = cast(
         bytes,
-        pkgutil.get_data("ethereum", f"assets/mainnet_genesis_alloc_rlp.hex"),
+        pkgutil.get_data("ethereum", "assets/mainnet_genesis_alloc_rlp.hex"),
     ).decode()
 
     return bytes.fromhex(rlp_encoding_hex)

--- a/tests/frontier/vm/vm_test_helpers.py
+++ b/tests/frontier/vm/vm_test_helpers.py
@@ -1,6 +1,5 @@
 import json
 import os
-from functools import partial
 from typing import Any
 
 from ethereum.base_types import U256, Uint
@@ -14,10 +13,10 @@ from ethereum.frontier.state import (
     set_storage,
     storage_root,
 )
+from ethereum.frontier.utils.hexadecimal import hex_to_address
 from ethereum.frontier.vm import Environment
 from ethereum.frontier.vm.interpreter import process_call
 from ethereum.utils.hexadecimal import (
-    hex_to_address,
     hex_to_bytes,
     hex_to_bytes32,
     hex_to_u256,


### PR DESCRIPTION
### What was wrong?

Code outside of the `frontier` package depended on `frontier` types.

### How was it fixed?

Moved fork-specific code into `frontier`

#### Cute Animal Picture

![pugsly](https://user-images.githubusercontent.com/57262657/128936477-5a1dd69f-b2b3-4777-bdfc-b452396c1a43.jpg)

